### PR TITLE
Fix for blinking list

### DIFF
--- a/lib/pages/scan/scan_bloc.dart
+++ b/lib/pages/scan/scan_bloc.dart
@@ -62,8 +62,6 @@ class ScanBloc extends Bloc<ScanEvent, ScanState> {
         _list.add(res.data);
         _list = _list.toSet().toList();
         yield ScanLoaded(_list);
-      } else {
-        yield ScanError(res.message);
       }
     }
   }

--- a/test/scan_bloc_test.dart
+++ b/test/scan_bloc_test.dart
@@ -30,10 +30,10 @@ void main() {
       expect: () => [ScanLoaded([searchResult1])],
     );
     blocTest(
-      'emits ScanError("error") when GetCompanyEvent(0) is added',
+      'emits nothing when GetCompanyEvent(0) is added',
       build: () => scanBloc,
       act: (bloc) => scanBloc.add(GetCompanyEvent(0)),
-      expect: () => [ScanError("error")],
+      expect: () => [],
     );
   });
 }


### PR DESCRIPTION
Problem z skaczącą listą pochodzi od biblioteki - przy pewnych kodach wysyłał error, a aplikacja to przechwytywała i próbowała mapować. Niefart był taki, że na error wyświetlaliśmy pustą listę - stąd problem z "błyskaniem" listy.