### PR TITLE
Zamienniki dodane do widoku produktu

### DIFF
--- a/lib/models/replacement.dart
+++ b/lib/models/replacement.dart
@@ -1,0 +1,32 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'replacement.g.dart';
+
+@JsonSerializable()
+class Replacement extends Equatable {
+  final String? code;
+  final String? name;
+  final String? company;
+  final String? description;
+
+  @JsonKey(name: 'display_name')
+  final String? displayName;
+
+  Replacement({
+    required this.code,
+    required this.name,
+    required this.company,
+    required this.description,
+    required this.displayName,
+  });
+
+  factory Replacement.fromJson(Map<String, dynamic> json) =>
+      _$ReplacementFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ReplacementToJson(this);
+
+  @override
+  List<Object?> get props => [code, name, company, description, displayName];
+}
+

--- a/lib/models/replacement.g.dart
+++ b/lib/models/replacement.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'replacement.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Replacement _$ReplacementFromJson(Map<String, dynamic> json) => Replacement(
+      code: json['code'] as String?,
+      name: json['name'] as String?,
+      company: json['company'] as String?,
+      description: json['description'] as String?,
+      displayName: json['display_name'] as String?,
+    );
+
+Map<String, dynamic> _$ReplacementToJson(Replacement instance) =>
+    <String, dynamic>{
+      'code': instance.code,
+      'name': instance.name,
+      'company': instance.company,
+      'description': instance.description,
+      'display_name': instance.displayName,
+    };
+

--- a/lib/models/search_result.dart
+++ b/lib/models/search_result.dart
@@ -4,6 +4,7 @@ import 'package:pola_flutter/models/brand.dart';
 import 'package:pola_flutter/models/company.dart';
 import 'package:pola_flutter/models/donate.dart';
 import 'package:pola_flutter/models/report.dart';
+import 'package:pola_flutter/models/replacement.dart';
 
 part 'search_result.g.dart';
 
@@ -19,6 +20,7 @@ class SearchResult extends Equatable {
   final List<Company>? companies;
   final Report? report;
   final Donate? donate;
+  final List<Replacement>? replacements;
 
   @JsonKey(name: 'all_company_brands')
   final List<Brand>? allCompanyBrands;
@@ -32,6 +34,7 @@ class SearchResult extends Equatable {
       required this.companies,
       required this.report,
       required this.donate,
+      this.replacements,
       this.allCompanyBrands
       });
 
@@ -44,6 +47,7 @@ class SearchResult extends Equatable {
         companies = null,
         report = null,
         donate = null,
+        replacements = null,
         allCompanyBrands = null;
 
   factory SearchResult.fromJson(Map<String, dynamic> json) =>
@@ -53,5 +57,5 @@ class SearchResult extends Equatable {
 
   @override
   List<Object?> get props =>
-      [productId, code, name, cardType, altText, companies, report, donate];
+      [productId, code, name, cardType, altText, companies, report, donate, replacements];
 }

--- a/lib/models/search_result.g.dart
+++ b/lib/models/search_result.g.dart
@@ -21,6 +21,9 @@ SearchResult _$SearchResultFromJson(Map<String, dynamic> json) => SearchResult(
       donate: json['donate'] == null
           ? null
           : Donate.fromJson(json['donate'] as Map<String, dynamic>),
+      replacements: (json['replacements'] as List<dynamic>?)
+          ?.map((e) => Replacement.fromJson(e as Map<String, dynamic>))
+          .toList(),
       allCompanyBrands: (json['all_company_brands'] as List<dynamic>?)
           ?.map((e) => Brand.fromJson(e as Map<String, dynamic>))
           .toList(),
@@ -36,5 +39,6 @@ Map<String, dynamic> _$SearchResultToJson(SearchResult instance) =>
       'companies': instance.companies,
       'report': instance.report,
       'donate': instance.donate,
+      'replacements': instance.replacements,
       'all_company_brands': instance.allCompanyBrands,
     };

--- a/lib/pages/detail/detail.dart
+++ b/lib/pages/detail/detail.dart
@@ -91,10 +91,54 @@ class _DetailContent extends StatelessWidget {
         Padding(
             padding: EdgeInsets.all(8.0),
             child: Text(company.description ?? "")),
+        _ReplacementsText(searchResult),
         _DetailCompanyLogotype(company.logotypeUrl),
         _BrandLogotypes(searchResult.allCompanyBrands),
         _ReadMoreButton(searchResult)
       ],
+    );
+  }
+}
+
+class _ReplacementsText extends StatelessWidget {
+  final SearchResult searchResult;
+  const _ReplacementsText(this.searchResult, {Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final replacements = searchResult.replacements;
+    if (replacements == null || replacements.isEmpty) {
+      return SizedBox.shrink();
+    }
+
+    final text = replacements
+        .map((r) {
+          final name = r.name ?? '';
+          final companyDisplay = r.displayName ?? r.company ?? '';
+          if (name.isEmpty && companyDisplay.isEmpty) return null;
+          return "$name ($companyDisplay)".trim();
+        })
+        .whereType<String>()
+        .where((s) => s.isNotEmpty)
+        .join(", ");
+
+    if (text.isEmpty) {
+      return SizedBox.shrink();
+    }
+
+    return Padding(
+      padding: EdgeInsets.all(8.0),
+      child: RichText(
+        text: TextSpan(
+          style: DefaultTextStyle.of(context).style,
+          children: [
+            TextSpan(
+                text: 'Polskie zamienniki: ',
+                style: TextStyle(fontWeight: FontWeight.bold)),
+            TextSpan(text: text),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/pages/detail/detail_lidl.dart
+++ b/lib/pages/detail/detail_lidl.dart
@@ -20,8 +20,8 @@ class LidlDetailPage extends StatelessWidget {
         ),
       ),
       body: SafeArea(
-        child: Column(
-          children: [
+          child: Column(
+            children: [
             Padding(
                 padding: EdgeInsets.all(12.0),
                 child: Align(
@@ -60,6 +60,50 @@ class LidlDetailPage extends StatelessWidget {
                 ],
               ),
             ),
+            _ReplacementsText(searchResult),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ReplacementsText extends StatelessWidget {
+  final SearchResult searchResult;
+  const _ReplacementsText(this.searchResult, {Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final replacements = searchResult.replacements;
+    if (replacements == null || replacements.isEmpty) {
+      return SizedBox.shrink();
+    }
+
+    final text = replacements
+        .map((r) {
+          final name = r.name ?? '';
+          final companyDisplay = r.displayName ?? r.company ?? '';
+          if (name.isEmpty && companyDisplay.isEmpty) return null;
+          return "$name ($companyDisplay)".trim();
+        })
+        .whereType<String>()
+        .where((s) => s.isNotEmpty)
+        .join(", ");
+
+    if (text.isEmpty) {
+      return SizedBox.shrink();
+    }
+
+    return Padding(
+      padding: EdgeInsets.all(8.0),
+      child: RichText(
+        text: TextSpan(
+          style: DefaultTextStyle.of(context).style,
+          children: [
+            TextSpan(
+                text: 'Polskie zamienniki: ',
+                style: TextStyle(fontWeight: FontWeight.bold)),
+            TextSpan(text: text),
           ],
         ),
       ),


### PR DESCRIPTION
Korzysta z logiki zwracanie zamienników, zaimplementowanej na backendzie przez: https://github.com/KlubJagiellonski/pola-backend/pull/4674  

Przykładowy output z tego zapytania wygląda:
```json
{
  "product_id": 20,
  "code": "0000000000019",
  "name": "company_official_43",
  "card_type": "type_white",
  "altText": null,
  "companies": [ ...
  ],
  "replacements": [
    {
      "code": "0000000000014",
      "name": "product14",
      "company": "common_brand_name14",
      "description": "xwYnPTfSGeSC",
      "display_name": "common_brand_name14"
    },
    {
      "code": "0000000000016",
      "name": "product16",
      "company": "common_brand_name16",
      "description": "cWlrJHDFxoMR",
      "display_name": "common_brand_name16"
    }
  ],
  "report": {
    "text": "Polskie alternatywy: product14 (common_brand_name14), product16 (common_brand_name16)\n---\nZgłoś jeśli posiadasz bardziej aktualne dane na temat tego produktu",
    "button_text": "Zgłoś",
    "button_type": "type_white"
  },
  "donate": {
    "show_button": true,
    "title": "1,5% podatku na aplikację Pola?",
    "url": "https://www.pola-app.pl/1-5-podatku-na-aplikacje-pola"
  }
}
```