### PR TITLE
Add Linting rules & cleanup warnings/info

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,9 @@
+include: package:flutter_lints/flutter.yaml
+
+analyzer:
+  exclude:
+    - build/**
+    - lib/**/*.g.dart
+    - lib/**/*.freezed.dart
+    - lib/**/*.chopper.dart
+    - lib/**/*.gen.dart

--- a/lib/analytics/analytics_provider.dart
+++ b/lib/analytics/analytics_provider.dart
@@ -1,4 +1,5 @@
 import 'package:firebase_analytics/firebase_analytics.dart';
+import 'package:flutter/foundation.dart';
 
 abstract class AnalyticsProvider {
   void logEvent(String name, [Map<String, dynamic>? parameters]);
@@ -19,7 +20,7 @@ class FirebaseAnalyticsProvider implements AnalyticsProvider {
 class ConsoleAnalyticsProvider implements AnalyticsProvider {
   @override
   void logEvent(String name, [Map<String, dynamic>? parameters]) {
-    print('Analytics event: $name, parameters: $parameters');
+    debugPrint('Analytics event: $name, parameters: $parameters');
   }
 }
 

--- a/lib/analytics/pola_analytics.dart
+++ b/lib/analytics/pola_analytics.dart
@@ -34,9 +34,7 @@ class PolaAnalytics {
       AnalyticsProductResultParameters(
         code: result.code,
         company: result.name,
-        productId: result.productId != null
-            ? result.productId.toString()
-            : null,
+        productId: result.productId?.toString(),
       ).toJson(),
     );
   }
@@ -47,9 +45,7 @@ class PolaAnalytics {
       AnalyticsProductResultParameters(
         code: result.code,
         company: result.name,
-        productId: result.productId != null
-            ? result.productId.toString()
-            : null,
+        productId: result.productId?.toString(),
       ).toJson(),
     );
   }
@@ -60,9 +56,7 @@ class PolaAnalytics {
       AnalyticsReadMoreParameters(
         code: result.code,
         company: result.name,
-        productId: result.productId != null
-            ? result.productId.toString()
-            : null,
+        productId: result.productId?.toString(),
         url: url,
       ).toJson(),
     );

--- a/lib/data/api_response.dart
+++ b/lib/data/api_response.dart
@@ -1,4 +1,4 @@
-enum Status { LOADING, COMPLETED, ERROR }
+enum Status { loading, completed, error }
 
 class ApiResponse<T> {
   Status status;
@@ -6,9 +6,9 @@ class ApiResponse<T> {
   late T data;
   late String message;
 
-  ApiResponse.completed(this.data) : status = Status.COMPLETED;
+  ApiResponse.completed(this.data) : status = Status.completed;
 
-  ApiResponse.error(this.message) : status = Status.ERROR;
+  ApiResponse.error(this.message) : status = Status.error;
 
   @override
   String toString() {

--- a/lib/data/device_id_service.dart
+++ b/lib/data/device_id_service.dart
@@ -1,5 +1,6 @@
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:uuid/uuid.dart';
+import 'package:flutter/foundation.dart';
 
 class DeviceIdService {
   DeviceIdService(this.uuid);
@@ -17,8 +18,8 @@ class DeviceIdService {
   }
 }
 
-saveDeviceId(String id) async {
+Future<void> saveDeviceId(String id) async {
   SharedPreferences prefs = await SharedPreferences.getInstance();
-  print('saving device_id ' + id);
+  debugPrint('saving device_id $id');
   await prefs.setString('device_id', id);
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,12 +3,12 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:logging/logging.dart';
 import 'package:pola_flutter/config/firebase_config.dart';
 import 'package:pola_flutter/i18n/strings.g.dart';
 import 'package:pola_flutter/pola_tab_controller.dart';
 import 'package:pola_flutter/firebase_options.dart';
 import 'package:pola_flutter/ui/flavor_banner.dart';
+import 'package:logging/logging.dart' as logging;
 
 const _appFlavor = String.fromEnvironment(
   'FLUTTER_APP_FLAVOR',
@@ -30,6 +30,8 @@ void main() async {
 }
 
 class PolaApp extends StatelessWidget {
+  const PolaApp({super.key});
+
   @override
   Widget build(BuildContext context) {
     SystemChrome.setPreferredOrientations([
@@ -52,20 +54,20 @@ class SimpleBlocObserver extends BlocObserver {
   @override
   void onTransition(Bloc bloc, Transition transition) {
     super.onTransition(bloc, transition);
-    print(transition);
+    debugPrint(transition.toString());
   }
 
   @override
   void onError(BlocBase bloc, Object error, StackTrace stackTrace) {
-    print(error);
+    debugPrint(error.toString());
     super.onError(bloc, error, stackTrace);
   }
 }
 
 void _setupLogging() {
   Bloc.observer = SimpleBlocObserver();
-  Logger.root.level = Level.ALL;
-  Logger.root.onRecord.listen((rec) {
-    print('${rec.level.name}: ${rec.time}: ${rec.message}');
+  logging.Logger.root.level = logging.Level.ALL;
+  logging.Logger.root.onRecord.listen((rec) {
+    debugPrint('${rec.level.name}: ${rec.time}: ${rec.message}');
   });
 }

--- a/lib/models/brand.dart
+++ b/lib/models/brand.dart
@@ -9,7 +9,11 @@ class Brand extends Equatable {
   final String? logotypeUrl;
   final String? websiteUrl;
 
-  Brand({required this.name, required this.logotypeUrl, required this.websiteUrl});
+  const Brand({
+    required this.name,
+    required this.logotypeUrl,
+    required this.websiteUrl,
+  });
 
   factory Brand.fromJson(Map<String, dynamic> json) => _$BrandFromJson(json);
 

--- a/lib/models/company.dart
+++ b/lib/models/company.dart
@@ -34,25 +34,26 @@ class Company extends Equatable {
 
   final List<Brand>? brands;
 
-  Company(
-      {required this.name,
-      required this.plCapital,
-      required this.plCapitalNotes,
-      required this.plWorkers,
-      required this.plWorkersNotes,
-      required this.plRnD,
-      required this.plRnDNotes,
-      required this.plRegistered,
-      required this.plRegisteredNotes,
-      required this.plNotGlobEnt,
-      required this.plNotGlobEntNotes,
-      required this.plScore,
-      required this.isFriend,
-      required this.friendText,
-      required this.description,
-      required this.logotypeUrl,
-      required this.officialUrl,
-      required this.brands});
+  const Company({
+    required this.name,
+    required this.plCapital,
+    required this.plCapitalNotes,
+    required this.plWorkers,
+    required this.plWorkersNotes,
+    required this.plRnD,
+    required this.plRnDNotes,
+    required this.plRegistered,
+    required this.plRegisteredNotes,
+    required this.plNotGlobEnt,
+    required this.plNotGlobEntNotes,
+    required this.plScore,
+    required this.isFriend,
+    required this.friendText,
+    required this.description,
+    required this.logotypeUrl,
+    required this.officialUrl,
+    required this.brands,
+  });
 
   factory Company.fromJson(Map<String, dynamic> json) =>
       _$CompanyFromJson(json);
@@ -60,24 +61,24 @@ class Company extends Equatable {
   Map<String, dynamic> toJson() => _$CompanyToJson(this);
   @override
   List<Object?> get props => [
-        name,
-        plCapital,
-        plCapitalNotes,
-        plWorkers,
-        plWorkersNotes,
-        plRnD,
-        plRnDNotes,
-        plRegistered,
-        plRegisteredNotes,
-        plNotGlobEnt,
-        plNotGlobEntNotes,
-        plScore,
-        isFriend,
-        friendText,
-        description,
-        logotypeUrl,
-        officialUrl
-      ];
+    name,
+    plCapital,
+    plCapitalNotes,
+    plWorkers,
+    plWorkersNotes,
+    plRnD,
+    plRnDNotes,
+    plRegistered,
+    plRegisteredNotes,
+    plNotGlobEnt,
+    plNotGlobEntNotes,
+    plScore,
+    isFriend,
+    friendText,
+    description,
+    logotypeUrl,
+    officialUrl,
+  ];
 
   int? getScore() {
     return plScore;

--- a/lib/models/donate.dart
+++ b/lib/models/donate.dart
@@ -9,7 +9,11 @@ class Donate extends Equatable {
   final String url;
   final String title;
 
-  Donate({required this.showButton, required this.url, required this.title});
+  const Donate({
+    required this.showButton,
+    required this.url,
+    required this.title,
+  });
 
   factory Donate.fromJson(Map<String, dynamic> json) => _$DonateFromJson(json);
 

--- a/lib/models/replacement.dart
+++ b/lib/models/replacement.dart
@@ -12,18 +12,26 @@ class Replacement extends Equatable {
   final String displayName;
   final bool isFriend;
 
-  Replacement(
-    {required this.name, 
+  const Replacement({
+    required this.name,
     required this.code,
-    required this.company, 
+    required this.company,
     required this.description,
     required this.displayName,
-    required this.isFriend});
+    required this.isFriend,
+  });
 
-  factory Replacement.fromJson(Map<String, dynamic> json) => _$ReplacementFromJson(json);
+  factory Replacement.fromJson(Map<String, dynamic> json) =>
+      _$ReplacementFromJson(json);
 
   Map<String, dynamic> toJson() => _$ReplacementToJson(this);
 
   @override
-  List<Object?> get props => [name, company, description, displayName, isFriend];
+  List<Object?> get props => [
+    name,
+    company,
+    description,
+    displayName,
+    isFriend,
+  ];
 }

--- a/lib/models/report.dart
+++ b/lib/models/report.dart
@@ -9,8 +9,11 @@ class Report extends Equatable {
   final String buttonText;
   final String? buttonType;
 
-  Report(
-      {required this.text, required this.buttonText, required this.buttonType});
+  const Report({
+    required this.text,
+    required this.buttonText,
+    required this.buttonType,
+  });
 
   factory Report.fromJson(Map<String, dynamic> json) => _$ReportFromJson(json);
 

--- a/lib/models/search_result.dart
+++ b/lib/models/search_result.dart
@@ -21,28 +21,28 @@ class SearchResult extends Equatable {
   final Donate? donate;
   final List<Replacement>? replacements;
 
-  SearchResult(
-      {required this.productId,
-      required this.code,
-      required this.name,
-      required this.cardType,
-      this.altText,
-      required this.companies,
-      required this.report,
-      required this.donate,
-      this.replacements,
-      });
+  const SearchResult({
+    required this.productId,
+    required this.code,
+    required this.name,
+    required this.cardType,
+    this.altText,
+    required this.companies,
+    required this.report,
+    required this.donate,
+    this.replacements,
+  });
 
-  SearchResult.empty()
-      : productId = null,
-        code = null,
-        name = null,
-        cardType = null,
-        altText = null,
-        companies = null,
-        report = null,
-        donate = null,
-        replacements = null;
+  const SearchResult.empty()
+    : productId = null,
+      code = null,
+      name = null,
+      cardType = null,
+      altText = null,
+      companies = null,
+      report = null,
+      donate = null,
+      replacements = null;
 
   factory SearchResult.fromJson(Map<String, dynamic> json) =>
       _$SearchResultFromJson(json);
@@ -50,6 +50,14 @@ class SearchResult extends Equatable {
   Map<String, dynamic> toJson() => _$SearchResultToJson(this);
 
   @override
-  List<Object?> get props =>
-      [productId, code, name, cardType, altText, companies, report, donate];
+  List<Object?> get props => [
+    productId,
+    code,
+    name,
+    cardType,
+    altText,
+    companies,
+    report,
+    donate,
+  ];
 }

--- a/lib/pages/detail/company_score_widget.dart
+++ b/lib/pages/detail/company_score_widget.dart
@@ -19,15 +19,16 @@ class CompanyScoreData {
   final List<Replacement>? replacements;
   final String productCode;
 
-  CompanyScoreData(
-      {required this.plCapital,
-      required this.plWorkers,
-      required this.plRnD,
-      required this.plRegistered,
-      required this.plNotGlobEnt,
-      required this.plScore,
-      required this.replacements,
-      required this.productCode});
+  CompanyScoreData({
+    required this.plCapital,
+    required this.plWorkers,
+    required this.plRnD,
+    required this.plRegistered,
+    required this.plNotGlobEnt,
+    required this.plScore,
+    required this.replacements,
+    required this.productCode,
+  });
 }
 
 class CompanyScoreWidget extends StatelessWidget {
@@ -74,23 +75,29 @@ class CompanyScoreWidget extends StatelessWidget {
         Padding(
           padding: const EdgeInsets.symmetric(vertical: 8.0),
           child: ClipRRect(
-              borderRadius: BorderRadius.circular(10.0),
-              child: TweenAnimationBuilder(
-                  duration: Duration(milliseconds: data.plScore * 10),
-                  tween: Tween<double>(begin: 0, end: data.plScore.toDouble()),
-                  builder: (_, double score, __) {
-                    return LinearProgressIndicator(
-                      value: score / 100.0,
-                      backgroundColor: AppColors.buttonBackground,
-                      valueColor: const AlwaysStoppedAnimation<Color>(
-                          AppColors.defaultRed),
-                      minHeight: 12.0,
-                    );
-                  })),
+            borderRadius: BorderRadius.circular(10.0),
+            child: TweenAnimationBuilder(
+              duration: Duration(milliseconds: data.plScore * 10),
+              tween: Tween<double>(begin: 0, end: data.plScore.toDouble()),
+              builder: (_, double score, Widget? child) {
+                return LinearProgressIndicator(
+                  value: score / 100.0,
+                  backgroundColor: AppColors.buttonBackground,
+                  valueColor: const AlwaysStoppedAnimation<Color>(
+                    AppColors.defaultRed,
+                  ),
+                  minHeight: 12.0,
+                );
+              },
+            ),
+          ),
         ),
         const SizedBox(height: 17.0),
         if (replacements != null && replacements.isNotEmpty) ...[
-          ReplacementsSection(replacements: replacements, productCode: data.productCode),
+          ReplacementsSection(
+            replacements: replacements,
+            productCode: data.productCode,
+          ),
           const SizedBox(height: 17.0),
         ],
         Divider(
@@ -129,10 +136,14 @@ class CompanyScoreWidget extends StatelessWidget {
                   _DetailItem(t.companyScreen.researchInPoland, data.plRnD),
                   const SizedBox(height: 14.0),
                   _DetailItem(
-                      t.companyScreen.registeredInPoland, data.plRegistered),
+                    t.companyScreen.registeredInPoland,
+                    data.plRegistered,
+                  ),
                   const SizedBox(height: 14.0),
                   _DetailItem(
-                      t.companyScreen.notConcernPart, data.plNotGlobEnt),
+                    t.companyScreen.notConcernPart,
+                    data.plNotGlobEnt,
+                  ),
                 ],
               ),
             ),
@@ -151,7 +162,7 @@ class CompanyScoreWidget extends StatelessWidget {
 }
 
 class _DetailItem extends StatelessWidget {
-  const _DetailItem(this.text, this.state, {Key? key}) : super(key: key);
+  const _DetailItem(this.text, this.state);
 
   final String text;
   final bool state;
@@ -163,10 +174,11 @@ class _DetailItem extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
         Padding(
-            padding: const EdgeInsets.only(right: 3.0),
-            child: state
-                ? Assets.company.taskAlt.svg()
-                : Assets.company.radioButtonUnchecked.svg()),
+          padding: const EdgeInsets.only(right: 3.0),
+          child: state
+              ? Assets.company.taskAlt.svg()
+              : Assets.company.radioButtonUnchecked.svg(),
+        ),
         Expanded(
           child: Text(
             text,

--- a/lib/pages/detail/detail.dart
+++ b/lib/pages/detail/detail.dart
@@ -8,7 +8,7 @@ import 'package:pola_flutter/pages/detail/text_marquee.dart';
 import 'package:pola_flutter/theme/text_size.dart';
 
 class DetailPage extends StatelessWidget {
-  DetailPage({Key? key, required this.searchResult}) : super(key: key);
+  const DetailPage({super.key, required this.searchResult});
 
   final SearchResult searchResult;
 
@@ -20,10 +20,10 @@ class DetailPage extends StatelessWidget {
 
     return Scaffold(
       backgroundColor: Colors.white,
-      
+
       appBar: AppBar(
         title: TextMarquee(
-          searchResult.name ?? "",
+          text: searchResult.name ?? "",
           style: TextStyle(
             color: AppColors.text,
             fontSize: TextSize.newsTitle,
@@ -39,10 +39,7 @@ class DetailPage extends StatelessWidget {
       body: SafeArea(
         child: SingleChildScrollView(
           child: Column(
-            children: [
-              SizedBox(height: 16.0),
-              DetailContent(searchResult),
-            ],
+            children: [SizedBox(height: 16.0), DetailContent(searchResult)],
           ),
         ),
       ),

--- a/lib/pages/detail/detail_content.dart
+++ b/lib/pages/detail/detail_content.dart
@@ -14,7 +14,7 @@ import 'no_score_message.dart';
 import 'friends_bar.dart';
 
 class DetailContent extends StatelessWidget {
-  const DetailContent(this.searchResult, {Key? key}) : super(key: key);
+  const DetailContent(this.searchResult, {super.key});
 
   final SearchResult searchResult;
 
@@ -57,9 +57,7 @@ class DetailContent extends StatelessWidget {
                   ),
               ],
               if (hasLogo)
-                Logotypes(
-                    logotypes: logotypes,
-                    searchResult: searchResult),
+                Logotypes(logotypes: logotypes, searchResult: searchResult),
               const SizedBox(height: 26.0),
               if (hasLogo && searchResult.report != null)
                 Divider(
@@ -132,7 +130,7 @@ class _ReportButton extends StatelessWidget {
 }
 
 class DetailItem extends StatelessWidget {
-  const DetailItem(this.text, this.state, {Key? key}) : super(key: key);
+  const DetailItem(this.text, this.state, {super.key});
 
   final String text;
   final bool state;
@@ -168,31 +166,36 @@ class DetailItem extends StatelessWidget {
 }
 
 extension on Company {
-    List<Logotype> logotypes() {
+  List<Logotype> logotypes() {
     final brands = this.brands;
     var logotypes = <Logotype>[];
     if (brands != null) {
-      logotypes = brands.map((brand) {
-        final logotypeUrl = brand.logotypeUrl;
-        final websiteUrl = brand.websiteUrl;
-        if (logotypeUrl == null || websiteUrl == null) {
-          return null;
-        }
-          return Logotype(logotypeUrl, websiteUrl);
-      }).where((logotype) => logotype != null)
-      .cast<Logotype>()
-      .toList();
+      logotypes = brands
+          .map((brand) {
+            final logotypeUrl = brand.logotypeUrl;
+            final websiteUrl = brand.websiteUrl;
+            if (logotypeUrl == null || websiteUrl == null) {
+              return null;
+            }
+            return Logotype(logotypeUrl, websiteUrl);
+          })
+          .where((logotype) => logotype != null)
+          .cast<Logotype>()
+          .toList();
     }
 
-    final companyLogotypeUrl = this.logotypeUrl;
-    final companyWebsiteUrl = this.officialUrl;
+    final companyLogotypeUrl = logotypeUrl;
+    final companyWebsiteUrl = officialUrl;
     if (companyLogotypeUrl != null && companyWebsiteUrl != null) {
       logotypes.insert(0, Logotype(companyLogotypeUrl, companyWebsiteUrl));
     }
     return logotypes;
   }
 
-  CompanyScoreData? _scoreData(List<Replacement>? replacements, String? productCode) {
+  CompanyScoreData? _scoreData(
+    List<Replacement>? replacements,
+    String? productCode,
+  ) {
     final int? plCapital = this.plCapital;
     final int? plWorkers = this.plWorkers;
     final int? plRnD = this.plRnD;
@@ -207,14 +210,15 @@ extension on Company {
         plNotGlobEnt != null &&
         plScore != null) {
       return CompanyScoreData(
-          plCapital: plCapital.toDouble(),
-          plWorkers: plWorkers != 0,
-          plRnD: plRnD != 0,
-          plRegistered: plRegistered != 0,
-          plNotGlobEnt: plNotGlobEnt != 0,
-          plScore: plScore,
-          replacements: replacements,
-          productCode: productCode ?? '');
+        plCapital: plCapital.toDouble(),
+        plWorkers: plWorkers != 0,
+        plRnD: plRnD != 0,
+        plRegistered: plRegistered != 0,
+        plNotGlobEnt: plNotGlobEnt != 0,
+        plScore: plScore,
+        replacements: replacements,
+        productCode: productCode ?? '',
+      );
     }
     return null;
   }
@@ -228,7 +232,10 @@ class _ScoreSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final scoreData = company._scoreData(searchResult.replacements, searchResult.code);
+    final scoreData = company._scoreData(
+      searchResult.replacements,
+      searchResult.code,
+    );
 
     if (scoreData != null) {
       return CompanyScoreWidget(data: scoreData);

--- a/lib/pages/detail/detail_lidl.dart
+++ b/lib/pages/detail/detail_lidl.dart
@@ -3,7 +3,7 @@ import 'package:pola_flutter/models/search_result.dart';
 import 'package:pola_flutter/ui/progress_indicator_text.dart';
 
 class LidlDetailPage extends StatelessWidget {
-  LidlDetailPage({Key? key, required this.searchResult}) : super(key: key);
+  const LidlDetailPage({super.key, required this.searchResult});
 
   final SearchResult searchResult;
 
@@ -14,8 +14,8 @@ class LidlDetailPage extends StatelessWidget {
       backgroundColor: Colors.white,
       appBar: AppBar(
         title: Text(searchResult.name ?? ""),
-        leading: new IconButton(
-          icon: new Icon(Icons.arrow_back),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
           onPressed: () => Navigator.of(context).pop(),
         ),
       ),
@@ -23,40 +23,46 @@ class LidlDetailPage extends StatelessWidget {
         child: Column(
           children: [
             Padding(
-                padding: EdgeInsets.all(12.0),
-                child: Align(
-                  child: Text(searchResult.name ?? "",
-                      style: TextStyle(
-                        fontSize: 18.0,
-                      )),
-                  alignment: Alignment.centerLeft,
-                )),
-            LinearProgressIndicatorWithText(0, "?"),
+              padding: EdgeInsets.all(12.0),
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  searchResult.name ?? "",
+                  style: TextStyle(fontSize: 18.0),
+                ),
+              ),
+            ),
+            LinearProgressIndicatorWithText(progress: 0, text: "?"),
             Padding(
               padding: EdgeInsets.all(8.0),
               child: Column(
                 children: [
                   Padding(
-                      padding: EdgeInsets.all(4.0),
-                      child: Align(
-                        child: Text(companies![1].name ?? ""),
-                        alignment: Alignment.centerLeft,
-                      )),
+                    padding: EdgeInsets.all(4.0),
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: Text(companies![1].name ?? ""),
+                    ),
+                  ),
                   LinearProgressIndicatorWithText(
-                      (companies[1].plScore ?? 0).toDouble(),
-                      (companies[1].plScore ?? 0).toString() + "%"),
+                    progress: (companies[1].plScore ?? 0).toDouble(),
+                    text: "(${companies[1].plScore ?? 0})",
+                  ),
                   Padding(
-                      padding: EdgeInsets.all(4.0),
-                      child: Align(
-                        child: Text(companies[0].name ?? ""),
-                        alignment: Alignment.centerLeft,
-                      )),
+                    padding: EdgeInsets.all(4.0),
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: Text(companies[0].name ?? ""),
+                    ),
+                  ),
                   LinearProgressIndicatorWithText(
-                      (companies[0].plScore ?? 0).toDouble(),
-                      (companies[0].plScore ?? 0).toString() + "%"),
+                    progress: (companies[0].plScore ?? 0).toDouble(),
+                    text: "(${companies[0].plScore ?? 0})",
+                  ),
                   Padding(
-                      padding: EdgeInsets.all(8.0),
-                      child: Text(companies[0].description ?? ""))
+                    padding: EdgeInsets.all(8.0),
+                    child: Text(companies[0].description ?? ""),
+                  ),
                 ],
               ),
             ),

--- a/lib/pages/detail/expandandable_text.dart
+++ b/lib/pages/detail/expandandable_text.dart
@@ -6,13 +6,13 @@ import 'package:pola_flutter/theme/fonts.gen.dart';
 
 class ExpandableText extends StatefulWidget {
   final String text;
-  ExpandableText(this.text);
+  const ExpandableText(this.text, {super.key});
 
   @override
-  _ExpandableTextState createState() => _ExpandableTextState();
+  ExpandableTextState createState() => ExpandableTextState();
 }
 
-class _ExpandableTextState extends State<ExpandableText> {
+class ExpandableTextState extends State<ExpandableText> {
   bool isExpanded = false;
 
   @override
@@ -38,7 +38,7 @@ class _ExpandableTextState extends State<ExpandableText> {
         final textSpan = TextSpan(
           text: widget.text,
           style: TextStyle(
-            color:AppColors.text,
+            color: AppColors.text,
             fontSize: 11.0,
             fontWeight: FontWeight.w400,
             fontFamily: FontFamily.lato,
@@ -68,25 +68,25 @@ class _ExpandableTextState extends State<ExpandableText> {
         );
 
         if (!isExpanded && textPainter.didExceedMaxLines) {
-          final pos = textPainter.getPositionForOffset(Offset(
-            textPainter.width - linkTextPainter.width,
-            textPainter.height,
-          ));
+          final pos = textPainter.getPositionForOffset(
+            Offset(
+              textPainter.width - linkTextPainter.width,
+              textPainter.height,
+            ),
+          );
           final end = textPainter.getOffsetBefore(pos.offset);
           final text = TextSpan(
             text: widget.text.substring(0, end),
-            style: TextStyle(color:AppColors.text),
+            style: TextStyle(color: AppColors.text),
             children: [link],
           );
 
-          return RichText(
-            text: text,
-          );
+          return RichText(text: text);
         } else {
           return RichText(
             text: TextSpan(
               text: widget.text,
-              style: TextStyle(color:AppColors.text),
+              style: TextStyle(color: AppColors.text),
               children: [if (isExpanded) link],
             ),
           );

--- a/lib/pages/detail/friends_bar.dart
+++ b/lib/pages/detail/friends_bar.dart
@@ -7,47 +7,52 @@ import 'package:pola_flutter/ui/web_view_dialog.dart';
 import 'package:pola_flutter/i18n/strings.g.dart';
 
 class FriendsBar extends StatelessWidget {
+  const FriendsBar({super.key});
   @override
   Widget build(BuildContext context) {
     final Translations t = Translations.of(context);
     return Padding(
-        padding: const EdgeInsets.only(bottom: 20.0),
-        child: GestureDetector(
-          onTap: () {
-            showWebViewDialog(
-                context: context,
-                url: "https://www.pola-app.pl/m/friends",
-                title: t.companyScreen.polaFriends);
-          },
-          child: Container(
-            height: 40.0,
-            color: AppColors.buttonBackground,
-            alignment: Alignment.center,
-            child: Row(
-              children: [
-                Padding(
-                    padding: const EdgeInsets.only(left: 19.0),
-                    child: Assets.company.heart.svg()),
-                Expanded(
-                  child: Center(
-                    child: Text(
-                      t.companyScreen.companyFriend,
-                      style: TextStyle(
-                        fontSize: TextSize.smallTitle,
-                        fontWeight: FontWeight.w700,
-                        fontFamily: FontFamily.lato,
-                        color: AppColors.defaultRed,
-                      ),
-                      textAlign: TextAlign.center,
+      padding: const EdgeInsets.only(bottom: 20.0),
+      child: GestureDetector(
+        onTap: () {
+          showWebViewDialog(
+            context: context,
+            url: "https://www.pola-app.pl/m/friends",
+            title: t.companyScreen.polaFriends,
+          );
+        },
+        child: Container(
+          height: 40.0,
+          color: AppColors.buttonBackground,
+          alignment: Alignment.center,
+          child: Row(
+            children: [
+              Padding(
+                padding: const EdgeInsets.only(left: 19.0),
+                child: Assets.company.heart.svg(),
+              ),
+              Expanded(
+                child: Center(
+                  child: Text(
+                    t.companyScreen.companyFriend,
+                    style: TextStyle(
+                      fontSize: TextSize.smallTitle,
+                      fontWeight: FontWeight.w700,
+                      fontFamily: FontFamily.lato,
+                      color: AppColors.defaultRed,
                     ),
+                    textAlign: TextAlign.center,
                   ),
                 ),
-                Padding(
-                    padding: const EdgeInsets.only(right: 19.0),
-                    child: Assets.company.heart.svg()),
-              ],
-            ),
+              ),
+              Padding(
+                padding: const EdgeInsets.only(right: 19.0),
+                child: Assets.company.heart.svg(),
+              ),
+            ],
           ),
-        ));
+        ),
+      ),
+    );
   }
 }

--- a/lib/pages/detail/logotypes.dart
+++ b/lib/pages/detail/logotypes.dart
@@ -16,7 +16,7 @@ class Logotypes extends StatelessWidget {
   final SearchResult searchResult;
   final PolaAnalytics analytics = PolaAnalytics.instance();
 
-  Logotypes({required this.logotypes, required this.searchResult});
+  Logotypes({super.key, required this.logotypes, required this.searchResult});
 
   @override
   Widget build(BuildContext context) {
@@ -35,10 +35,7 @@ class Logotypes extends StatelessWidget {
               if (uri == null) return;
 
               analytics.readMore(searchResult, url);
-              launchUrl(
-                uri,
-                mode: LaunchMode.externalApplication,
-              );
+              launchUrl(uri, mode: LaunchMode.externalApplication);
             },
             child: Padding(
               padding: EdgeInsets.all(8.0),
@@ -69,7 +66,7 @@ class Logotypes extends StatelessWidget {
 }
 
 class _LogoView extends StatelessWidget {
-  _LogoView(this.url);
+  const _LogoView(this.url);
 
   final String url;
 

--- a/lib/pages/detail/no_score_message.dart
+++ b/lib/pages/detail/no_score_message.dart
@@ -7,6 +7,8 @@ import 'package:pola_flutter/theme/text_size.dart';
 import 'package:pola_flutter/i18n/strings.g.dart';
 
 class NoScoreMessage extends StatelessWidget {
+  const NoScoreMessage({super.key});
+
   @override
   Widget build(BuildContext context) {
     final Translations t = Translations.of(context);
@@ -16,8 +18,10 @@ class NoScoreMessage extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Center(
-            child:
-                Assets.company.unpublished.svg(height: 109.42, width: 109.55),
+            child: Assets.company.unpublished.svg(
+              height: 109.42,
+              width: 109.55,
+            ),
           ),
           const SizedBox(height: 26.0),
           Text(
@@ -40,7 +44,7 @@ class NoScoreMessage extends StatelessWidget {
               color: AppColors.text,
             ),
             textAlign: TextAlign.left,
-          )
+          ),
         ],
       ),
     );

--- a/lib/pages/detail/polish_capital_graph.dart
+++ b/lib/pages/detail/polish_capital_graph.dart
@@ -7,7 +7,7 @@ import 'package:pola_flutter/i18n/strings.g.dart';
 class PolishCapitalGraph extends StatelessWidget {
   final double percentage;
 
-  PolishCapitalGraph({required this.percentage});
+  const PolishCapitalGraph({super.key, required this.percentage});
 
   @override
   Widget build(BuildContext context) {
@@ -17,52 +17,55 @@ class PolishCapitalGraph extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
         SizedBox(
-            height: size,
-            width: size,
-            child: TweenAnimationBuilder(
-                duration: Duration(milliseconds: percentage.toInt() * 10),
-                tween: Tween<double>(begin: 0, end: percentage),
-                builder: (_, double score, __) {
-                  return SfRadialGauge(
-                    axes: <RadialAxis>[
-                      RadialAxis(
-                        minimum: 0,
-                        maximum: 100,
-                        showLabels: false,
-                        showTicks: false,
-                        axisLineStyle: AxisLineStyle(
-                          thickness: thickness,
-                          cornerStyle: CornerStyle.bothCurve,
-                          color: AppColors.buttonBackground,
-                          thicknessUnit: GaugeSizeUnit.factor,
-                        ),
-                        pointers: <GaugePointer>[
-                          RangePointer(
-                            value: score,
-                            cornerStyle: CornerStyle.bothCurve,
-                            width: thickness,
-                            sizeUnit: GaugeSizeUnit.factor,
-                            color: AppColors.defaultRed,
-                          ),
-                        ],
-                        annotations: <GaugeAnnotation>[
-                          GaugeAnnotation(
-                            positionFactor: 0.01,
-                            angle: 90,
-                            widget: Text(
-                              '${percentage.toInt()}%',
-                              style: TextStyle(
-                                  fontSize: 26.0,
-                                  fontWeight: FontWeight.w700,
-                                  fontFamily: FontFamily.lato,
-                                  color: AppColors.text),
-                            ),
-                          ),
-                        ],
+          height: size,
+          width: size,
+          child: TweenAnimationBuilder(
+            duration: Duration(milliseconds: percentage.toInt() * 10),
+            tween: Tween<double>(begin: 0, end: percentage),
+            builder: (_, double score, Widget? child) {
+              return SfRadialGauge(
+                axes: <RadialAxis>[
+                  RadialAxis(
+                    minimum: 0,
+                    maximum: 100,
+                    showLabels: false,
+                    showTicks: false,
+                    axisLineStyle: AxisLineStyle(
+                      thickness: thickness,
+                      cornerStyle: CornerStyle.bothCurve,
+                      color: AppColors.buttonBackground,
+                      thicknessUnit: GaugeSizeUnit.factor,
+                    ),
+                    pointers: <GaugePointer>[
+                      RangePointer(
+                        value: score,
+                        cornerStyle: CornerStyle.bothCurve,
+                        width: thickness,
+                        sizeUnit: GaugeSizeUnit.factor,
+                        color: AppColors.defaultRed,
                       ),
                     ],
-                  );
-                })),
+                    annotations: <GaugeAnnotation>[
+                      GaugeAnnotation(
+                        positionFactor: 0.01,
+                        angle: 90,
+                        widget: Text(
+                          '${percentage.toInt()}%',
+                          style: TextStyle(
+                            fontSize: 26.0,
+                            fontWeight: FontWeight.w700,
+                            fontFamily: FontFamily.lato,
+                            color: AppColors.text,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              );
+            },
+          ),
+        ),
         Padding(
           padding: const EdgeInsets.only(top: 0.0),
           child: Text(

--- a/lib/pages/detail/replacement/replacement_bloc.dart
+++ b/lib/pages/detail/replacement/replacement_bloc.dart
@@ -12,17 +12,25 @@ class ReplacementBloc extends Bloc<ReplacementEvent, ReplacementState> {
   final PolaApi _polaApiRepository;
   final PolaAnalytics _analytics;
 
-  ReplacementBloc(this._polaApiRepository, this._analytics, {required ReplacementState state}) : super(state) {
+  ReplacementBloc(
+    this._polaApiRepository,
+    this._analytics, {
+    required ReplacementState state,
+  }) : super(state) {
     on<ReplacementEvent>((event, emit) async {
       await event.when(
-        replacementTapped: (replacement) async => await _onReplacementTapped(replacement, emit),
+        replacementTapped: (replacement) async =>
+            await _onReplacementTapped(replacement, emit),
         resultPushed: () async => _onResultPushed(emit),
         alertDialogDismissed: () async => _onAlertDialogDismissed(emit),
       );
     });
   }
 
-  Future<void> _onReplacementTapped(Replacement replacement, Emitter<ReplacementState> emit) async {
+  Future<void> _onReplacementTapped(
+    Replacement replacement,
+    Emitter<ReplacementState> emit,
+  ) async {
     if (state.loadingReplacement != null || state.isError) {
       return;
     }
@@ -39,16 +47,18 @@ class ReplacementBloc extends Bloc<ReplacementEvent, ReplacementState> {
     debugPrint('Loading replacement for code: ${replacement.code}');
 
     final response = await _polaApiRepository.getCompany(replacement.code);
-    
-    if (response.status == Status.COMPLETED) {
+
+    if (response.status == Status.completed) {
       final updatedResults = Map<String, SearchResult>.from(state.results);
       updatedResults[replacement.code] = response.data;
-      emit(state.copyWith(
-        loadingReplacement: null,
-        results: updatedResults,
-        resultToPush: response.data,
-        isError: false,
-      ));
+      emit(
+        state.copyWith(
+          loadingReplacement: null,
+          results: updatedResults,
+          resultToPush: response.data,
+          isError: false,
+        ),
+      );
     } else {
       emit(state.copyWith(loadingReplacement: null, isError: true));
     }
@@ -62,4 +72,3 @@ class ReplacementBloc extends Bloc<ReplacementEvent, ReplacementState> {
     emit(state.copyWith(isError: false));
   }
 }
-

--- a/lib/pages/detail/replacement/replacements_section.dart
+++ b/lib/pages/detail/replacement/replacements_section.dart
@@ -15,7 +15,11 @@ import 'package:pola_flutter/theme/fonts.gen.dart';
 import 'package:pola_flutter/theme/text_size.dart';
 
 class ReplacementsSection extends StatelessWidget {
-  const ReplacementsSection({Key? key, required this.replacements, required this.productCode}) : super(key: key);
+  const ReplacementsSection({
+    super.key,
+    required this.replacements,
+    required this.productCode,
+  });
 
   final List<Replacement> replacements;
   final String productCode;
@@ -27,24 +31,31 @@ class ReplacementsSection extends StatelessWidget {
     }
 
     final Translations t = Translations.of(context);
-    
+
     return BlocProvider(
-      create: (context) => ReplacementBloc(PolaApiRepository(), PolaAnalytics.instance(), state: ReplacementState(productCode: productCode)),
-        child: BlocListener<ReplacementBloc, ReplacementState>(
-          listener: (context, state) {
-            if (state.resultToPush != null) {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => DetailPage(searchResult: state.resultToPush!),
-                ),
-              ).then((_) {
+      create: (context) => ReplacementBloc(
+        PolaApiRepository(),
+        PolaAnalytics.instance(),
+        state: ReplacementState(productCode: productCode),
+      ),
+      child: BlocListener<ReplacementBloc, ReplacementState>(
+        listener: (context, state) {
+          if (state.resultToPush != null) {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (context) =>
+                    DetailPage(searchResult: state.resultToPush!),
+              ),
+            ).then((_) {
+              if (context.mounted) {
                 context.read<ReplacementBloc>().add(
                   const ReplacementEvent.resultPushed(),
                 );
-              });
-            }
-          },
+              }
+            });
+          }
+        },
         child: BlocBuilder<ReplacementBloc, ReplacementState>(
           builder: (context, state) {
             if (state.isError) {
@@ -95,7 +106,9 @@ class ReplacementsSection extends StatelessWidget {
                     itemBuilder: (context, index) {
                       return Padding(
                         padding: EdgeInsets.only(right: 11.0),
-                        child: _ReplacementCard(replacement: replacements[index]),
+                        child: _ReplacementCard(
+                          replacement: replacements[index],
+                        ),
                       );
                     },
                   ),
@@ -110,7 +123,7 @@ class ReplacementsSection extends StatelessWidget {
 }
 
 class _ReplacementCard extends StatelessWidget {
-  const _ReplacementCard({Key? key, required this.replacement}) : super(key: key);
+  const _ReplacementCard({required this.replacement});
 
   final Replacement replacement;
 
@@ -118,7 +131,8 @@ class _ReplacementCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocBuilder<ReplacementBloc, ReplacementState>(
       builder: (context, state) {
-        final isLoadingForThisCard = state.loadingReplacement?.code == replacement.code;
+        final isLoadingForThisCard =
+            state.loadingReplacement?.code == replacement.code;
 
         return GestureDetector(
           onTap: isLoadingForThisCard
@@ -129,75 +143,70 @@ class _ReplacementCard extends StatelessWidget {
                   );
                 },
           child: Container(
-              width: 160.0,
-              decoration: BoxDecoration(
-                color: AppColors.buttonBackground,
-                borderRadius: BorderRadius.circular(8.0),
-              ),
-              child: Stack(
-                children: [
-                  Padding(
-                    padding: const EdgeInsets.all(9.0),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Expanded(
-                          child: Text(
-                            replacement.displayName.isNotEmpty
-                                ? replacement.displayName
-                                : replacement.name,
-                            style: TextStyle(
-                              fontSize: TextSize.description,
-                              fontWeight: FontWeight.w400,
-                              fontFamily: FontFamily.lato,
-                              color: AppColors.text,
-                            ),
-                            maxLines: 3,
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        ),
-                        const SizedBox(height: 1.0),
-                        Row(
-                          crossAxisAlignment: CrossAxisAlignment.center,
-                          children: [
-                            Expanded(
-                              child: Text(
-                                replacement.company,
-                                style: TextStyle(
-                                  fontSize: 9.0,
-                                  fontWeight: FontWeight.w400,
-                                  fontFamily: FontFamily.lato,
-                                  color: AppColors.inactive,
-                                ),
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
-                              ),
-                            ),
-                            if (replacement.isFriend) ...[
-                              const SizedBox(width: 4.0),
-                              Assets.company.heart.svg(
-                                width: 16.0,
-                                height: 16.0,
-                              ),
-                            ],
-                          ],
-                        ),
-                      ],
-                    ),
-                  ),
-                  if (isLoadingForThisCard)
-                    Container(
-                      decoration: BoxDecoration(
-                        color: Colors.black.withValues(alpha: 0.3),
-                        borderRadius: BorderRadius.circular(8.0),
-                      ),
-                      child: const Center(
-                        child: CircularProgressIndicator(),
-                      ),
-                    ),
-                ],
-              ),
+            width: 160.0,
+            decoration: BoxDecoration(
+              color: AppColors.buttonBackground,
+              borderRadius: BorderRadius.circular(8.0),
             ),
+            child: Stack(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.all(9.0),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Expanded(
+                        child: Text(
+                          replacement.displayName.isNotEmpty
+                              ? replacement.displayName
+                              : replacement.name,
+                          style: TextStyle(
+                            fontSize: TextSize.description,
+                            fontWeight: FontWeight.w400,
+                            fontFamily: FontFamily.lato,
+                            color: AppColors.text,
+                          ),
+                          maxLines: 3,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      const SizedBox(height: 1.0),
+                      Row(
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        children: [
+                          Expanded(
+                            child: Text(
+                              replacement.company,
+                              style: TextStyle(
+                                fontSize: 9.0,
+                                fontWeight: FontWeight.w400,
+                                fontFamily: FontFamily.lato,
+                                color: AppColors.inactive,
+                              ),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                          if (replacement.isFriend) ...[
+                            const SizedBox(width: 4.0),
+                            Assets.company.heart.svg(width: 16.0, height: 16.0),
+                          ],
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+                if (isLoadingForThisCard)
+                  Container(
+                    decoration: BoxDecoration(
+                      color: Colors.black.withValues(alpha: 0.3),
+                      borderRadius: BorderRadius.circular(8.0),
+                    ),
+                    child: const Center(child: CircularProgressIndicator()),
+                  ),
+              ],
+            ),
+          ),
         );
       },
     );

--- a/lib/pages/detail/text_marquee.dart
+++ b/lib/pages/detail/text_marquee.dart
@@ -30,16 +30,17 @@ class TextMarquee extends StatefulWidget {
   final bool rtl;
 
   /// Create TextMarquee
-  const TextMarquee(this.text,
-      {Key? key,
-      this.style = const TextStyle(),
-      this.duration,
-      this.curve = Curves.linear,
-      this.delay = const Duration(seconds: 2),
-      this.spaceSize = 32,
-      this.startPaddingSize = 0,
-      this.rtl = false})
-      : super(key: key);
+  const TextMarquee({
+    super.key,
+    required this.text,
+    this.style = const TextStyle(),
+    this.duration,
+    this.curve = Curves.linear,
+    this.delay = const Duration(seconds: 2),
+    this.spaceSize = 32,
+    this.startPaddingSize = 0,
+    this.rtl = false,
+  });
 
   @override
   State<TextMarquee> createState() => _TextMarqueeState();
@@ -96,11 +97,13 @@ class _TextMarqueeState extends State<TextMarquee> {
         _textWidth + widget.spaceSize + widget.startPaddingSize;
 
     // Scroll to the end of SingleChildScrollView.
-    await _scrollController.animateTo(scrollLength,
-        duration: (widget.duration != null)
-            ? widget.duration!
-            : Duration(milliseconds: (scrollLength * 27).toInt()),
-        curve: widget.curve);
+    await _scrollController.animateTo(
+      scrollLength,
+      duration: (widget.duration != null)
+          ? widget.duration!
+          : Duration(milliseconds: (scrollLength * 27).toInt()),
+      curve: widget.curve,
+    );
 
     // Ensure the widget is still mounted before jumping
     if (!mounted) return;
@@ -128,24 +131,29 @@ class _TextMarqueeState extends State<TextMarquee> {
         return Directionality(
           textDirection: TextDirection.ltr,
           child: SingleChildScrollView(
-              scrollDirection: Axis.horizontal,
-              physics: const NeverScrollableScrollPhysics(),
-              controller: _scrollController,
-              reverse: widget.rtl,
-              child: Row(
-                children: [
-                  SizedBox(width: widget.startPaddingSize),
-                  Text(widget.text, style: widget.style, maxLines: 1),
-                  (_isLarger)
-                      ? Padding(
-                          padding: EdgeInsets.only(
-                              left: widget.spaceSize + widget.startPaddingSize),
-                          child: Text(widget.text,
-                              style: widget.style, maxLines: 1),
-                        )
-                      : const SizedBox()
-                ],
-              )),
+            scrollDirection: Axis.horizontal,
+            physics: const NeverScrollableScrollPhysics(),
+            controller: _scrollController,
+            reverse: widget.rtl,
+            child: Row(
+              children: [
+                SizedBox(width: widget.startPaddingSize),
+                Text(widget.text, style: widget.style, maxLines: 1),
+                (_isLarger)
+                    ? Padding(
+                        padding: EdgeInsets.only(
+                          left: widget.spaceSize + widget.startPaddingSize,
+                        ),
+                        child: Text(
+                          widget.text,
+                          style: widget.style,
+                          maxLines: 1,
+                        ),
+                      )
+                    : const SizedBox(),
+              ],
+            ),
+          ),
         );
       },
     );
@@ -173,10 +181,12 @@ class _TextMarqueeState extends State<TextMarquee> {
     renderObject.layout(constraints);
 
     // Get text width from render object.
-    final boxes = renderObject.getBoxesForSelection(TextSelection(
-      baseOffset: 0,
-      extentOffset: TextSpan(text: widget.text).toPlainText().length,
-    ));
+    final boxes = renderObject.getBoxesForSelection(
+      TextSelection(
+        baseOffset: 0,
+        extentOffset: TextSpan(text: widget.text).toPlainText().length,
+      ),
+    );
 
     // Return width of text.
     return boxes.last.right;

--- a/lib/pages/dialpad/dialpad.dart
+++ b/lib/pages/dialpad/dialpad.dart
@@ -1,13 +1,12 @@
 import 'package:flutter/material.dart';
 
 class DialPadPage extends StatefulWidget {
-  const DialPadPage({Key? key}) : super(key: key);
-
+  const DialPadPage({super.key});
   @override
-  _DialPadPageState createState() => _DialPadPageState();
+  DialPadPageState createState() => DialPadPageState();
 }
 
-class _DialPadPageState extends State<DialPadPage> {
+class DialPadPageState extends State<DialPadPage> {
   late String ean = "";
 
   @override
@@ -19,166 +18,189 @@ class _DialPadPageState extends State<DialPadPage> {
   @override
   Widget build(BuildContext context) {
     const textStyle = TextStyle(
-        fontWeight: FontWeight.normal, fontSize: 60.0, color: Colors.black);
+      fontWeight: FontWeight.normal,
+      fontSize: 60.0,
+      color: Colors.black,
+    );
 
     return Scaffold(
-        backgroundColor: Colors.grey,
-        appBar: AppBar(
-          title: Text("Wpisz kod EAN z opakowania"),
-          leading: new IconButton(
-            icon: new Icon(Icons.arrow_back),
-            onPressed: () => Navigator.of(context).pop(),
-          ),
+      backgroundColor: Colors.grey,
+      appBar: AppBar(
+        title: Text("Wpisz kod EAN z opakowania"),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.of(context).pop(),
         ),
-        body: SafeArea(
-          child: Center(
-              child: Column(
+      ),
+      body: SafeArea(
+        child: Center(
+          child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
               Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  Text(ean,
-                      style: TextStyle(
-                          fontWeight: FontWeight.normal,
-                          fontSize: 40.0,
-                          color: Colors.red[700])),
+                  Text(
+                    ean,
+                    style: TextStyle(
+                      fontWeight: FontWeight.normal,
+                      fontSize: 40.0,
+                      color: Colors.red[700],
+                    ),
+                  ),
                 ],
               ),
-              Row(mainAxisSize: MainAxisSize.min, children: [
-                Divider(height: 10, thickness: 1, color: Colors.black),
-              ]),
               Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  TextButton(
-                      onPressed: () {
-                        setState(() {
-                          {
-                            ean = ean + "1";
-                          }
-                        });
-                      },
-                      child: const Text('1', style: textStyle)),
-                  TextButton(
-                      onPressed: () {
-                        setState(() {
-                          {
-                            ean = ean + "2";
-                          }
-                        });
-                      },
-                      child: const Text('2', style: textStyle)),
-                  TextButton(
-                      onPressed: () {
-                        setState(() {
-                          {
-                            ean = ean + "3";
-                          }
-                        });
-                      },
-                      child: const Text('3', style: textStyle))
+                  Divider(height: 10, thickness: 1, color: Colors.black),
                 ],
               ),
               Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   TextButton(
-                      onPressed: () {
-                        setState(() {
-                          {
-                            ean = ean + "4";
-                          }
-                        });
-                      },
-                      child: const Text('4', style: textStyle)),
+                    onPressed: () {
+                      setState(() {
+                        {
+                          ean = "$ean + 1";
+                        }
+                      });
+                    },
+                    child: const Text('1', style: textStyle),
+                  ),
                   TextButton(
-                      onPressed: () {
-                        setState(() {
-                          {
-                            ean = ean + "5";
-                          }
-                        });
-                      },
-                      child: const Text('5', style: textStyle)),
+                    onPressed: () {
+                      setState(() {
+                        {
+                          ean = "$ean + 2";
+                        }
+                      });
+                    },
+                    child: const Text('2', style: textStyle),
+                  ),
                   TextButton(
-                      onPressed: () {
-                        setState(() {
-                          {
-                            ean = ean + "6";
-                          }
-                        });
-                      },
-                      child: const Text('6', style: textStyle))
+                    onPressed: () {
+                      setState(() {
+                        {
+                          ean = "$ean + 3";
+                        }
+                      });
+                    },
+                    child: const Text('3', style: textStyle),
+                  ),
                 ],
               ),
               Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   TextButton(
-                      onPressed: () {
-                        setState(() {
-                          {
-                            ean = ean + "7";
-                          }
-                        });
-                      },
-                      child: const Text('7', style: textStyle)),
+                    onPressed: () {
+                      setState(() {
+                        {
+                          ean = "$ean + 4";
+                        }
+                      });
+                    },
+                    child: const Text('4', style: textStyle),
+                  ),
                   TextButton(
-                      onPressed: () {
-                        setState(() {
-                          {
-                            ean = ean + "8";
-                          }
-                        });
-                      },
-                      child: const Text('8', style: textStyle)),
+                    onPressed: () {
+                      setState(() {
+                        {
+                          ean = "$ean + 5";
+                        }
+                      });
+                    },
+                    child: const Text('5', style: textStyle),
+                  ),
                   TextButton(
-                      onPressed: () {
-                        setState(() {
-                          {
-                            ean = ean + "9";
-                          }
-                        });
-                      },
-                      child: const Text('9', style: textStyle))
+                    onPressed: () {
+                      setState(() {
+                        {
+                          ean = "$ean + 6";
+                        }
+                      });
+                    },
+                    child: const Text('6', style: textStyle),
+                  ),
                 ],
               ),
               Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   TextButton(
-                      onPressed: () {
-                        setState(() {
-                          {
-                            if (ean.length >= 2) {
-                              ean = ean.substring(0, ean.length - 1);
-                            }
-                            if (ean.length == 1) {
-                              ean = "";
-                            }
-                          }
-                        });
-                      },
-                      child: const Text('<', style: textStyle)),
+                    onPressed: () {
+                      setState(() {
+                        {
+                          ean = "$ean + 7";
+                        }
+                      });
+                    },
+                    child: const Text('7', style: textStyle),
+                  ),
                   TextButton(
-                      onPressed: () {
-                        setState(() {
-                          {
-                            ean = ean + "0";
-                          }
-                        });
-                      },
-                      child: const Text('0', style: textStyle)),
+                    onPressed: () {
+                      setState(() {
+                        {
+                          ean = "$ean + 8";
+                        }
+                      });
+                    },
+                    child: const Text('8', style: textStyle),
+                  ),
                   TextButton(
-                      onPressed: () {
-                        Navigator.pop(context, ean);
-                      },
-                      child: const Text('x', style: textStyle))
+                    onPressed: () {
+                      setState(() {
+                        {
+                          ean = "$ean + 9";
+                        }
+                      });
+                    },
+                    child: const Text('9', style: textStyle),
+                  ),
                 ],
-              )
+              ),
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  TextButton(
+                    onPressed: () {
+                      setState(() {
+                        {
+                          if (ean.length >= 2) {
+                            ean = ean.substring(0, ean.length - 1);
+                          }
+                          if (ean.length == 1) {
+                            ean = "";
+                          }
+                        }
+                      });
+                    },
+                    child: const Text('<', style: textStyle),
+                  ),
+                  TextButton(
+                    onPressed: () {
+                      setState(() {
+                        {
+                          ean = "$ean + 0";
+                        }
+                      });
+                    },
+                    child: const Text('0', style: textStyle),
+                  ),
+                  TextButton(
+                    onPressed: () {
+                      Navigator.pop(context, ean);
+                    },
+                    child: const Text('x', style: textStyle),
+                  ),
+                ],
+              ),
             ],
-          )),
-        ));
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/lib/pages/menu/menu_footer.dart
+++ b/lib/pages/menu/menu_footer.dart
@@ -5,27 +5,28 @@ import 'package:pola_flutter/theme/fonts.gen.dart';
 import 'package:pola_flutter/theme/text_size.dart';
 
 class MenuFooter extends StatelessWidget {
+  const MenuFooter({super.key});
   @override
   Widget build(BuildContext context) {
     final Translations t = Translations.of(context);
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 32.0),
       child: Row(
+        crossAxisAlignment: CrossAxisAlignment.baseline,
+        textBaseline: TextBaseline.alphabetic,
         children: [
           Text(
             t.menu.footer,
             style: TextStyle(
               fontSize: TextSize.smallTitle,
               fontWeight: FontWeight.w600,
-              fontFamily: FontFamily.lato
+              fontFamily: FontFamily.lato,
             ),
           ),
           Expanded(child: Container()),
           VersionWidget(),
         ],
-        crossAxisAlignment: CrossAxisAlignment.baseline,
-        textBaseline: TextBaseline.alphabetic,
-      )
+      ),
     );
   }
 }

--- a/lib/pages/menu/version_bloc.dart
+++ b/lib/pages/menu/version_bloc.dart
@@ -6,9 +6,7 @@ part 'version_bloc.freezed.dart';
 
 @freezed
 abstract class VersionState with _$VersionState {
-  const factory VersionState({
-    @Default(null) String? version,
-  }) = Initial;
+  const factory VersionState({@Default(null) String? version}) = Initial;
 }
 
 @freezed
@@ -17,15 +15,13 @@ class VersionEvent with _$VersionEvent {
 }
 
 class VersionBloc extends Bloc<VersionEvent, VersionState> {
-  VersionBloc(): super(VersionState()) {
+  VersionBloc() : super(VersionState()) {
     on<VersionEvent>((event, emit) async {
-      await event.when(
-        onApear: () async => await _onApear(emit)
-      );
+      await event.when(onApear: () async => await _onApear(emit));
     });
   }
 
-  _onApear(Emitter<VersionState> emit) async {
+  Future<void> _onApear(Emitter<VersionState> emit) async {
     PackageInfo packageInfo = await PackageInfo.fromPlatform();
     String version = packageInfo.version;
     String buildNumber = packageInfo.buildNumber;

--- a/lib/pages/menu/version_widget.dart
+++ b/lib/pages/menu/version_widget.dart
@@ -6,14 +6,16 @@ import 'package:pola_flutter/theme/text_size.dart';
 import 'package:pola_flutter/pages/menu/version_bloc.dart';
 
 class VersionWidget extends StatelessWidget {
+  const VersionWidget({super.key});
   @override
   Widget build(BuildContext context) {
-    return BlocProvider(create: (context) => VersionBloc()..add(VersionEvent.onApear()), 
+    return BlocProvider(
+      create: (context) => VersionBloc()..add(VersionEvent.onApear()),
       child: BlocBuilder<VersionBloc, VersionState>(
         builder: (context, state) {
           return _VersionLabelWidget(version: state.version);
         },
-      )
+      ),
     );
   }
 }
@@ -23,7 +25,7 @@ class _VersionLabelWidget extends StatelessWidget {
 
   const _VersionLabelWidget({this.version});
 
-    @override
+  @override
   Widget build(BuildContext context) {
     String? version = this.version;
     if (version == null) {

--- a/lib/pages/report/report_page.dart
+++ b/lib/pages/report/report_page.dart
@@ -14,7 +14,7 @@ import 'package:pola_flutter/theme/text_size.dart';
 class ReportPage extends StatefulWidget {
   final int? productId;
 
-  const ReportPage({Key? key, this.productId}) : super(key: key);
+  const ReportPage({super.key, this.productId});
 
   @override
   State<ReportPage> createState() => _ReportPageState();
@@ -32,7 +32,8 @@ class _ReportPageState extends State<ReportPage> {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (_) => ReportBloc(PolaApiRepository(), productId: widget.productId),
+      create: (_) =>
+          ReportBloc(PolaApiRepository(), productId: widget.productId),
       child: BlocConsumer<ReportBloc, ReportState>(
         listenWhen: (prev, curr) =>
             prev.requestState != ReportRequestState.success &&
@@ -63,7 +64,9 @@ class _ReportPageState extends State<ReportPage> {
               child: state.requestState == ReportRequestState.success
                   ? Padding(
                       padding: const EdgeInsets.symmetric(
-                          horizontal: 17.0, vertical: 24.0),
+                        horizontal: 17.0,
+                        vertical: 24.0,
+                      ),
                       child: ReportSuccessView(t: t),
                     )
                   : _FormView(
@@ -74,9 +77,9 @@ class _ReportPageState extends State<ReportPage> {
                       onSystemInfoChanged: (val) => context
                           .read<ReportBloc>()
                           .add(ReportEvent.systemInfoToggled(val)),
-                      onSubmit: () => context
-                          .read<ReportBloc>()
-                          .add(const ReportEvent.submitted()),
+                      onSubmit: () => context.read<ReportBloc>().add(
+                        const ReportEvent.submitted(),
+                      ),
                       onDescriptionChanged: (text) => context
                           .read<ReportBloc>()
                           .add(ReportEvent.descriptionChanged(text)),
@@ -114,8 +117,10 @@ class _FormView extends StatelessWidget {
       children: [
         Expanded(
           child: SingleChildScrollView(
-            padding:
-                const EdgeInsets.symmetric(horizontal: 17.0, vertical: 24.0),
+            padding: const EdgeInsets.symmetric(
+              horizontal: 17.0,
+              vertical: 24.0,
+            ),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
@@ -163,7 +168,9 @@ class _FormView extends StatelessWidget {
                   Text(
                     t.reportScreen.descriptionRequired,
                     style: const TextStyle(
-                        color: AppColors.defaultRed, fontSize: 13.0),
+                      color: AppColors.defaultRed,
+                      fontSize: 13.0,
+                    ),
                   ),
                 ],
                 const SizedBox(height: 16.0),
@@ -200,7 +207,9 @@ class _FormView extends StatelessWidget {
         Padding(
           padding: const EdgeInsets.fromLTRB(17.0, 8.0, 17.0, 16.0),
           child: ElevatedButton(
-            onPressed: requestState == ReportRequestState.loading ? null : onSubmit,
+            onPressed: requestState == ReportRequestState.loading
+                ? null
+                : onSubmit,
             style: ElevatedButton.styleFrom(
               backgroundColor: AppColors.defaultRed,
               disabledBackgroundColor: AppColors.inactive,

--- a/lib/pages/scan/companies_list.dart
+++ b/lib/pages/scan/companies_list.dart
@@ -7,8 +7,12 @@ import 'package:pola_flutter/ui/list_item.dart';
 import 'dart:math';
 
 class CompaniesList extends StatelessWidget {
-  CompaniesList(
-      this.state, this.listScrollController, this.onCloseRemoteButtonTap);
+  CompaniesList({
+    super.key,
+    required this.state,
+    required this.listScrollController,
+    required this.onCloseRemoteButtonTap,
+  });
 
   final ScanState state;
   final ScrollController listScrollController;
@@ -28,9 +32,7 @@ class CompaniesList extends StatelessWidget {
       children: <Widget>[
         _ListHeader(listSize: listSize),
         Container(
-          constraints: BoxConstraints(
-            maxHeight: maxHeight,
-          ),
+          constraints: BoxConstraints(maxHeight: maxHeight),
           child: Align(
             alignment: Alignment.bottomCenter,
             child: ListView.builder(
@@ -42,7 +44,7 @@ class CompaniesList extends StatelessWidget {
                   return LoadingListItem();
                 }
                 return GestureDetector(
-                  child: ResultListItem(state.list[index]),
+                  child: ResultListItem(searchResult: state.list[index]),
                   onTap: () {
                     final result = state.list[index];
                     _analytics.opensCard(result);

--- a/lib/pages/scan/remote_button.dart
+++ b/lib/pages/scan/remote_button.dart
@@ -10,7 +10,7 @@ class RemoteButtonState extends Equatable {
   final Uri uri;
   final String code;
 
-  RemoteButtonState({
+  const RemoteButtonState({
     required this.title,
     required this.uri,
     required this.code,
@@ -24,13 +24,21 @@ class RemoteButton extends StatelessWidget {
   final RemoteButtonState state;
   final GestureTapCallback onCloseTap;
 
-  RemoteButton(this.state, this.onCloseTap);
+  const RemoteButton({
+    super.key,
+    required this.state,
+    required this.onCloseTap,
+  });
 
   @override
   Widget build(BuildContext context) {
     return Container(
       margin: const EdgeInsets.only(
-          left: 16.0, right: 16.0, top: 9.0, bottom: 11.0),
+        left: 16.0,
+        right: 16.0,
+        top: 9.0,
+        bottom: 11.0,
+      ),
       decoration: BoxDecoration(
         color: AppColors.defaultRed,
         borderRadius: BorderRadius.circular(25),

--- a/lib/pages/scan/reset_button.dart
+++ b/lib/pages/scan/reset_button.dart
@@ -4,16 +4,14 @@ import 'package:pola_flutter/theme/assets.gen.dart';
 class ResetButton extends StatelessWidget {
   final VoidCallback onTap;
 
-  ResetButton({required this.onTap});
+  const ResetButton({super.key, required this.onTap});
 
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: onTap,
       child: Container(
-        decoration: BoxDecoration(
-          boxShadow: [],
-        ),
+        decoration: BoxDecoration(boxShadow: []),
         child: Assets.scan.historyButton.svg(),
       ),
     );

--- a/lib/pages/scan/scan.dart
+++ b/lib/pages/scan/scan.dart
@@ -26,13 +26,17 @@ class MainPage extends StatefulWidget {
   final RouteObserver<ModalRoute<dynamic>> routeObserver;
   final ValueNotifier<bool> scanTabActive;
 
-  const MainPage({required this.routeObserver, required this.scanTabActive});
+  const MainPage({
+    super.key,
+    required this.routeObserver,
+    required this.scanTabActive,
+  });
 
   @override
-  _MainPageState createState() => _MainPageState();
+  MainPageState createState() => MainPageState();
 }
 
-class _MainPageState extends State<MainPage> with RouteAware {
+class MainPageState extends State<MainPage> with RouteAware {
   late ScanBloc _scanBloc;
   MobileScannerController cameraController = MobileScannerController(
     detectionSpeed: DetectionSpeed.normal,
@@ -46,8 +50,12 @@ class _MainPageState extends State<MainPage> with RouteAware {
   @override
   void initState() {
     super.initState();
-    _scanBloc = ScanBloc(PolaApiRepository(), ScanVibrationImpl(), _analytics,
-        TorchControllerImpl(cameraController: cameraController));
+    _scanBloc = ScanBloc(
+      PolaApiRepository(),
+      ScanVibrationImpl(),
+      _analytics,
+      TorchControllerImpl(cameraController: cameraController),
+    );
     widget.scanTabActive.addListener(_onScanTabActiveChanged);
   }
 
@@ -94,9 +102,10 @@ class _MainPageState extends State<MainPage> with RouteAware {
           onPressed: () {
             _analytics.aboutPolaOpened();
             showWebViewDialog(
-                context: context,
-                url: "https://www.pola-app.pl/m/about",
-                title: t.menu.aboutPola);
+              context: context,
+              url: "https://www.pola-app.pl/m/about",
+              title: t.menu.aboutPola,
+            );
           },
           icon: Assets.icLauncher.image(),
         ),
@@ -118,12 +127,12 @@ class _MainPageState extends State<MainPage> with RouteAware {
           _buildQrView(context),
           SafeArea(
             child: Padding(
-              padding:
-                  const EdgeInsets.symmetric(vertical: 20.0, horizontal: 16.0),
+              padding: const EdgeInsets.symmetric(
+                vertical: 20.0,
+                horizontal: 16.0,
+              ),
               child: Column(
-                children: <Widget>[
-                  ScanSearchButton(analytics: _analytics),
-                ],
+                children: <Widget>[ScanSearchButton(analytics: _analytics)],
               ),
             ),
           ),
@@ -148,8 +157,9 @@ class _MainPageState extends State<MainPage> with RouteAware {
                                 TextButton(
                                   child: Text(t.scan.closeError),
                                   onPressed: () {
-                                    _scanBloc
-                                        .add(ScanEvent.alertDialogDismissed());
+                                    _scanBloc.add(
+                                      ScanEvent.alertDialogDismissed(),
+                                    );
                                     Navigator.pop(context);
                                   },
                                 ),
@@ -160,39 +170,49 @@ class _MainPageState extends State<MainPage> with RouteAware {
                       });
                     }
 
-                    return Column(children: [
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.end,
-                        children: [
-                          Expanded(
-                              child: CompaniesList(state, listScrollController,
-                                  () {
-                            _scanBloc.add(ScanEvent.closeRemoteButton());
-                          })),
-                          Column(
-                            children: [
-                              if (state.list.isNotEmpty)
-                                ResetButton(
-                                  onTap: () {
-                                    _scanBloc
-                                        .add(ScanEvent.resetScannedCompaniesButton());
-                                  },
-                                ),
-                              TorchButton(
-                                isTorchOn: state.isTorchOn,
-                                onTap: () {
-                                  _scanBloc.add(ScanEvent.torchSwitched());
+                    return Column(
+                      children: [
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.end,
+                          children: [
+                            Expanded(
+                              child: CompaniesList(
+                                state: state,
+                                listScrollController: listScrollController,
+                                onCloseRemoteButtonTap: () {
+                                  _scanBloc.add(ScanEvent.closeRemoteButton());
                                 },
                               ),
-                            ],
-                          )
-                        ],
-                      ),
-                      if (state.remoteButtonState != null)
-                        RemoteButton(state.remoteButtonState!, () {
-                          _scanBloc.add(ScanEvent.closeRemoteButton());
-                        })
-                    ]);
+                            ),
+                            Column(
+                              children: [
+                                if (state.list.isNotEmpty)
+                                  ResetButton(
+                                    onTap: () {
+                                      _scanBloc.add(
+                                        ScanEvent.resetScannedCompaniesButton(),
+                                      );
+                                    },
+                                  ),
+                                TorchButton(
+                                  isTorchOn: state.isTorchOn,
+                                  onTap: () {
+                                    _scanBloc.add(ScanEvent.torchSwitched());
+                                  },
+                                ),
+                              ],
+                            ),
+                          ],
+                        ),
+                        if (state.remoteButtonState != null)
+                          RemoteButton(
+                            state: state.remoteButtonState!,
+                            onCloseTap: () {
+                              _scanBloc.add(ScanEvent.closeRemoteButton());
+                            },
+                          ),
+                      ],
+                    );
                   },
                 ),
               ],

--- a/lib/pages/scan/scan_background.dart
+++ b/lib/pages/scan/scan_background.dart
@@ -5,6 +5,7 @@ import 'package:pola_flutter/theme/colors.dart';
 const double _rectangleHeight = 187.0;
 
 class ScanBackground extends StatelessWidget {
+  const ScanBackground({super.key});
   @override
   Widget build(BuildContext context) {
     return Column(
@@ -27,10 +28,7 @@ class _SizedBlackOpacity extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Expanded(
-      child: SizedBox(
-        height: _rectangleHeight,
-        child: _BlackContainer(),
-      ),
+      child: SizedBox(height: _rectangleHeight, child: _BlackContainer()),
     );
   }
 }
@@ -45,9 +43,7 @@ class _BlackOpacity extends StatelessWidget {
 class _BlackContainer extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Container(
-      color: AppColors.text.withValues(alpha: 0.7),
-    );
+    return Container(color: AppColors.text.withValues(alpha: 0.7));
   }
 }
 
@@ -90,17 +86,15 @@ class _RedRectangleState extends State<_RedRectangle>
         AnimatedBuilder(
           animation: _animation,
           builder: (context, child) {
-            final laserTop = _verticalMargin +
+            final laserTop =
+                _verticalMargin +
                 _animation.value * (_rectangleHeight - _verticalMargin * 2);
             return Positioned(
               top: laserTop,
               left: 0,
               right: 0,
               child: Center(
-                child: Container(
-                  height: 2,
-                  color: AppColors.defaultRed,
-                ),
+                child: Container(height: 2, color: AppColors.defaultRed),
               ),
             );
           },

--- a/lib/pages/scan/scan_bloc.dart
+++ b/lib/pages/scan/scan_bloc.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:pola_flutter/analytics/analytics_barcode_source.dart';
@@ -17,12 +19,15 @@ class ScanBloc extends Bloc<ScanEvent, ScanState> {
   final PolaAnalytics _analytics;
   final TorchController _torchController;
 
-  ScanBloc(this._polaApiRepository, this._scanVibration, this._analytics,
-      this._torchController,
-      {ScanState state = const ScanState()})
-      : super(state) {
-    on<ScanEvent>((event, emit) async {
-      await event.when(
+  ScanBloc(
+    this._polaApiRepository,
+    this._scanVibration,
+    this._analytics,
+    this._torchController, {
+    ScanState state = const ScanState(),
+  }) : super(state) {
+    on<ScanEvent>((event, emit) {
+      event.when(
         barcodeScanned: (barcode) async =>
             await _onBarcodeScanned(barcode, emit),
         alertDialogDismissed: () => _onAlertDialogDismissed(emit),
@@ -33,7 +38,10 @@ class ScanBloc extends Bloc<ScanEvent, ScanState> {
     });
   }
 
-  _onBarcodeScanned(String barcode, Emitter<ScanState> emit) async {
+  Future<void> _onBarcodeScanned(
+    String barcode,
+    Emitter<ScanState> emit,
+  ) async {
     if (state.list.any((element) => element.code == barcode) ||
         state.isLoading ||
         state.isError) {
@@ -43,10 +51,12 @@ class ScanBloc extends Bloc<ScanEvent, ScanState> {
     debugPrint('Scanned barcode event received: $barcode');
     _scanVibration.vibrate();
     _analytics.barcodeScanned(
-        barcode.toString(), AnalyticsBarcodeSource.camera);
+      barcode.toString(),
+      AnalyticsBarcodeSource.camera,
+    );
 
     final res = await _polaApiRepository.getCompany(barcode);
-    if (res.status == Status.COMPLETED) {
+    if (res.status == Status.completed) {
       final result = res.data;
       var results = List<SearchResult>.from(state.list);
       results.add(result);
@@ -55,31 +65,34 @@ class ScanBloc extends Bloc<ScanEvent, ScanState> {
       if (remoteButtonState == null && !state.wasRemoteButtonClosed) {
         remoteButtonState = result.remoteButton();
       }
-      emit(state.copyWith(
+      emit(
+        state.copyWith(
           list: results,
           isLoading: false,
           isError: false,
-          remoteButtonState: remoteButtonState));
+          remoteButtonState: remoteButtonState,
+        ),
+      );
     } else {
       emit(state.copyWith(isLoading: false, isError: true));
     }
   }
 
-  _onTorchSwitched(Emitter<ScanState> emit) {
+  void _onTorchSwitched(Emitter<ScanState> emit) {
     _torchController.toggleTorch();
 
     emit(state.copyWith(isTorchOn: !state.isTorchOn));
   }
 
-  _onAlertDialogDismissed(Emitter<ScanState> emit) {
+  void _onAlertDialogDismissed(Emitter<ScanState> emit) {
     emit(state.copyWith(isError: false));
   }
 
-  _onCloseRemoteButton(Emitter<ScanState> emit) {
+  void _onCloseRemoteButton(Emitter<ScanState> emit) {
     emit(state.copyWith(wasRemoteButtonClosed: true, remoteButtonState: null));
   }
 
-  _onResetScannedCompanies(Emitter<ScanState> emit) {
+  void _onResetScannedCompanies(Emitter<ScanState> emit) {
     emit(state.copyWith(list: []));
   }
 }

--- a/lib/pages/scan/scan_navigator.dart
+++ b/lib/pages/scan/scan_navigator.dart
@@ -11,7 +11,7 @@ class ScanNavigator extends StatefulWidget {
   final GlobalKey<NavigatorState>? navigatorKey;
   final bool isActive;
 
-  const ScanNavigator({this.navigatorKey, this.isActive = true});
+  const ScanNavigator({super.key, this.navigatorKey, this.isActive = true});
 
   @override
   State<ScanNavigator> createState() => _ScanNavigatorState();
@@ -73,37 +73,43 @@ class _ScanNavigatorState extends State<ScanNavigator> {
     switch (settings.name) {
       case '/':
         return MaterialPageRoute(
-            builder: (_) => MainPage(
-                routeObserver: routeObserver, scanTabActive: _scanTabActive));
+          builder: (_) => MainPage(
+            routeObserver: routeObserver,
+            scanTabActive: _scanTabActive,
+          ),
+        );
       case '/detail':
         if (args is SearchResult) {
           return MaterialPageRoute(
-            builder: (_) => DetailPage(
-              searchResult: args,
-            ),
+            builder: (_) => DetailPage(searchResult: args),
           );
         }
         return MaterialPageRoute(
-            builder: (_) => MainPage(
-                routeObserver: routeObserver, scanTabActive: _scanTabActive));
+          builder: (_) => MainPage(
+            routeObserver: routeObserver,
+            scanTabActive: _scanTabActive,
+          ),
+        );
       case '/dialpad':
         return MaterialPageRoute(builder: (_) => DialPadPage());
       case '/search':
         return MaterialPageRoute(
-            builder: (context) => WebViewTab(
-                title: Translations.of(context).search.title,
-                url: "https://www.pola-app.pl/m/search/"));
+          builder: (context) => WebViewTab(
+            title: Translations.of(context).search.title,
+            url: "https://www.pola-app.pl/m/search/",
+          ),
+        );
       case '/report':
         return MaterialPageRoute(
-          builder: (_) => ReportPage(
-            productId: args is int ? args : null,
-          ),
+          builder: (_) => ReportPage(productId: args is int ? args : null),
         );
       default:
         return MaterialPageRoute(
-            builder: (_) => MainPage(
-                routeObserver: routeObserver, scanTabActive: _scanTabActive));
+          builder: (_) => MainPage(
+            routeObserver: routeObserver,
+            scanTabActive: _scanTabActive,
+          ),
+        );
     }
   }
 }
-

--- a/lib/pages/scan/scan_search_button.dart
+++ b/lib/pages/scan/scan_search_button.dart
@@ -7,7 +7,7 @@ import 'package:pola_flutter/i18n/strings.g.dart';
 class ScanSearchButton extends StatelessWidget {
   final PolaAnalytics analytics;
 
-  const ScanSearchButton({Key? key, required this.analytics}) : super(key: key);
+  const ScanSearchButton({super.key, required this.analytics});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/pages/scan/torch_button.dart
+++ b/lib/pages/scan/torch_button.dart
@@ -5,16 +5,14 @@ class TorchButton extends StatelessWidget {
   final bool isTorchOn;
   final VoidCallback onTap;
 
-  TorchButton({required this.isTorchOn, required this.onTap});
+  const TorchButton({super.key, required this.isTorchOn, required this.onTap});
 
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: onTap,
       child: Container(
-        decoration: BoxDecoration(
-          boxShadow: [],
-        ),
+        decoration: BoxDecoration(boxShadow: []),
         child: isTorchOn
             ? Assets.scan.flashlightOn.svg()
             : Assets.scan.flashlightOff.svg(),

--- a/lib/pages/web/web_view_page.dart
+++ b/lib/pages/web/web_view_page.dart
@@ -3,8 +3,7 @@ import 'package:pola_flutter/theme/colors.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
 class WebViewPage extends StatefulWidget {
-  WebViewPage({Key? key, required this.url, this.canGoBackNotifier})
-      : super(key: key);
+  const WebViewPage({super.key, required this.url, this.canGoBackNotifier});
 
   final String url;
   final ValueNotifier<bool>? canGoBackNotifier;
@@ -36,21 +35,26 @@ class WebViewPageState extends State<WebViewPage> {
     controller = WebViewController()
       ..setJavaScriptMode(JavaScriptMode.unrestricted)
       ..setNavigationDelegate(
-        NavigationDelegate(onProgress: (int progress) {
-          setState(() {
-            loadingPercentage = progress;
-          });
-        }, onPageStarted: (String url) {
-          setState(() {
-            loadingPercentage = 0;
-          });
-        }, onPageFinished: (String url) {
-          setState(() {
-            loadingPercentage = 100;
-          });
-        }, onUrlChange: (UrlChange urlChange) {
-          _updateCanGoBack();
-        }),
+        NavigationDelegate(
+          onProgress: (int progress) {
+            setState(() {
+              loadingPercentage = progress;
+            });
+          },
+          onPageStarted: (String url) {
+            setState(() {
+              loadingPercentage = 0;
+            });
+          },
+          onPageFinished: (String url) {
+            setState(() {
+              loadingPercentage = 100;
+            });
+          },
+          onUrlChange: (UrlChange urlChange) {
+            _updateCanGoBack();
+          },
+        ),
       )
       ..setBackgroundColor(AppColors.white)
       ..loadRequest(Uri.parse(widget.url));
@@ -95,9 +99,7 @@ class WebViewPageState extends State<WebViewPage> {
         children: [
           WebViewWidget(controller: controller),
           if (loadingPercentage < 100)
-            LinearProgressIndicator(
-              value: loadingPercentage / 100.0,
-            ),
+            LinearProgressIndicator(value: loadingPercentage / 100.0),
         ],
       ),
     );

--- a/lib/pola_tab_controller.dart
+++ b/lib/pola_tab_controller.dart
@@ -8,6 +8,8 @@ import 'package:pola_flutter/theme/assets.gen.dart';
 import 'package:pola_flutter/ui/web_view_tab.dart';
 
 class PolaTabController extends StatefulWidget {
+  const PolaTabController({super.key});
+
   @override
   State<PolaTabController> createState() => _PolaTabControllerState();
 }
@@ -41,25 +43,22 @@ class _PolaTabControllerState extends State<PolaTabController> {
           onTap: _onItemTapped,
           currentIndex: _selectedIndex,
         ),
-        body: IndexedStack(
-          index: _selectedIndex,
-          children: _tabs,
-        ),
+        body: IndexedStack(index: _selectedIndex, children: _tabs),
       ),
     );
   }
 
   List<Widget> get _tabs => [
-        ScanNavigator(
-          navigatorKey: _scanNavigatorKey,
-          isActive: _selectedIndex == 0,
-        ),
-        WebViewTab(
-          title: t.news.title,
-          url: "https://www.pola-app.pl/m/blog/",
-          pageKey: _newsWebViewPageKey,
-        )
-      ];
+    ScanNavigator(
+      navigatorKey: _scanNavigatorKey,
+      isActive: _selectedIndex == 0,
+    ),
+    WebViewTab(
+      title: t.news.title,
+      url: "https://www.pola-app.pl/m/blog/",
+      pageKey: _newsWebViewPageKey,
+    ),
+  ];
 
   AnalyticsMainTab _getTabParameter(int index) {
     switch (index) {

--- a/lib/ui/flavor_banner.dart
+++ b/lib/ui/flavor_banner.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 class FlavorBanner extends StatelessWidget {
-  const FlavorBanner({required this.flavor, required this.child});
+  const FlavorBanner({super.key, required this.flavor, required this.child});
 
   final String flavor;
   final Widget child;

--- a/lib/ui/list_item.dart
+++ b/lib/ui/list_item.dart
@@ -7,7 +7,7 @@ import 'package:pola_flutter/theme/fonts.gen.dart';
 import 'package:pola_flutter/theme/text_size.dart';
 
 class ResultListItem extends StatelessWidget {
-  ResultListItem(this.searchResult);
+  const ResultListItem({super.key, required this.searchResult});
 
   final SearchResult searchResult;
   static const double leftBoxSize = 40.0;
@@ -83,11 +83,12 @@ class ResultListItem extends StatelessWidget {
 }
 
 class LoadingListItem extends StatelessWidget {
-  LoadingListItem();
+  const LoadingListItem({super.key});
 
   @override
   Widget build(BuildContext context) {
     return _ListItem(
+      showMore: false,
       child: Align(
         alignment: Alignment.centerLeft,
         child: Padding(
@@ -100,10 +101,8 @@ class LoadingListItem extends StatelessWidget {
                 child: Text(
                   t.scan.wait,
                   style: TextStyle(
-                    fontWeight:
-                        FontWeight.w400,
-                    fontSize:
-                        TextSize.smallTitle,
+                    fontWeight: FontWeight.w400,
+                    fontSize: TextSize.smallTitle,
                   ),
                 ),
               ),
@@ -111,7 +110,6 @@ class LoadingListItem extends StatelessWidget {
           ),
         ),
       ),
-      showMore: false,
     );
   }
 }
@@ -120,16 +118,13 @@ class _ListItem extends StatelessWidget {
   final Widget child;
   final bool showMore;
 
-  const _ListItem({
-    required this.child,
-    this.showMore = true,
-  });
+  const _ListItem({required this.child, this.showMore = true});
 
   @override
   Widget build(BuildContext context) {
     return Padding(
       padding: EdgeInsets.only(top: 4.0, left: 16.0, right: 8.0, bottom: 4.0),
-      child: Container(
+      child: SizedBox(
         height: 40,
         child: DecoratedBox(
           decoration: BoxDecoration(

--- a/lib/ui/progress_indicator_text.dart
+++ b/lib/ui/progress_indicator_text.dart
@@ -1,7 +1,11 @@
 import 'package:flutter/material.dart';
 
 class LinearProgressIndicatorWithText extends StatelessWidget {
-  LinearProgressIndicatorWithText(this.progress, this.text);
+  const LinearProgressIndicatorWithText({
+    super.key,
+    required this.progress,
+    required this.text,
+  });
 
   final String text;
   final double progress;
@@ -19,12 +23,10 @@ class LinearProgressIndicatorWithText extends StatelessWidget {
         Align(
           alignment: Alignment.centerRight,
           child: Padding(
-              padding: EdgeInsets.only(right: 16.0),
-              child: Text(
-                text,
-                style: TextStyle(color: Colors.white),
-              )),
-        )
+            padding: EdgeInsets.only(right: 16.0),
+            child: Text(text, style: TextStyle(color: Colors.white)),
+          ),
+        ),
       ],
     );
   }

--- a/lib/ui/web_view_dialog.dart
+++ b/lib/ui/web_view_dialog.dart
@@ -4,7 +4,11 @@ import 'package:pola_flutter/theme/assets.gen.dart';
 import 'package:pola_flutter/theme/colors.dart';
 import 'package:pola_flutter/theme/text_size.dart';
 
-showWebViewDialog({required BuildContext context, required String url, required String title}) {
+void showWebViewDialog({
+  required BuildContext context,
+  required String url,
+  required String title,
+}) {
   showDialog(
     context: context,
     useSafeArea: false,
@@ -18,8 +22,7 @@ class _WebViewDialog extends StatelessWidget {
   final String url;
   final String title;
 
-  const _WebViewDialog({Key? key, required this.url, required this.title})
-      : super(key: key);
+  const _WebViewDialog({required this.url, required this.title});
 
   @override
   Widget build(BuildContext context) {
@@ -36,8 +39,11 @@ class _WebViewDialog extends StatelessWidget {
           child: Column(
             children: [
               Padding(
-                padding:
-                    const EdgeInsets.only(left: 19.0, right: 17.0, top: 19.0),
+                padding: const EdgeInsets.only(
+                  left: 19.0,
+                  right: 17.0,
+                  top: 19.0,
+                ),
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
@@ -64,9 +70,7 @@ class _WebViewDialog extends StatelessWidget {
                   ],
                 ),
               ),
-              Expanded(
-                child: WebViewPage(url: url),
-              ),
+              Expanded(child: WebViewPage(url: url)),
             ],
           ),
         );

--- a/lib/ui/web_view_tab.dart
+++ b/lib/ui/web_view_tab.dart
@@ -6,11 +6,16 @@ import 'package:pola_flutter/theme/fonts.gen.dart';
 class WebViewTab extends StatefulWidget {
   final String title;
   final String url;
+
   /// Optional key to access the [WebViewPageState] from outside, for example to call [WebViewPageState.popToRootPage].
   final GlobalKey<WebViewPageState>? pageKey;
 
-  WebViewTab({Key? key, required this.title, required this.url, this.pageKey})
-      : super(key: key);
+  const WebViewTab({
+    super.key,
+    required this.title,
+    required this.url,
+    this.pageKey,
+  });
 
   @override
   State<WebViewTab> createState() => _WebViewTabState();
@@ -41,7 +46,9 @@ class _WebViewTabState extends State<WebViewTab> {
           builder: (context, canGoBack, _) {
             return AppBar(
               automaticallyImplyLeading: false,
-              leading: (canGoBack || Navigator.of(context).canPop()) ? BackButton() : null,
+              leading: (canGoBack || Navigator.of(context).canPop())
+                  ? BackButton()
+                  : null,
               title: Text(
                 widget.title,
                 style: TextStyle(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -430,6 +430,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.13.0+1"
+  flutter_lints:
+    dependency: "direct dev"
+    description:
+      name: flutter_lints
+      sha256: "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.0"
   flutter_localizations:
     dependency: transitive
     description: flutter
@@ -613,6 +621,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
+  lints:
+    dependency: transitive
+    description:
+      name: lints
+      sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.0"
   logger:
     dependency: "direct main"
     description:
@@ -622,7 +638,7 @@ packages:
     source: hosted
     version: "2.3.0"
   logging:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: logging
       sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pola_flutter
 description: A new Flutter project.
-publish_to: 'none' 
+publish_to: "none"
 version: 3.1.0+1
 
 environment:
@@ -37,6 +37,7 @@ dependencies:
   syncfusion_flutter_gauges: ^31.2.15
   flutter_svg: ^2.2.3
   package_info_plus: ^8.0.2
+  logging: ^1.3.0
 
 dev_dependencies:
   flutter_test:
@@ -48,6 +49,7 @@ dev_dependencies:
   test: any
   bloc_test: ^9.1.7
   mockito: ^5.6.4
+  flutter_lints: ^6.0.0
 
 flutter:
   config:
@@ -65,22 +67,22 @@ flutter:
     - assets/tabs/
 
   fonts:
-    - family: Roboto 
-      fonts: 
+    - family: Roboto
+      fonts:
         - asset: assets/fonts/Roboto/Roboto-Regular.ttf
         - asset: assets/fonts/Roboto/Roboto-Bold.ttf
           weight: 700
-    - family: Lato 
+    - family: Lato
       fonts:
         - asset: assets/fonts/Lato/Lato-Regular.ttf
         - asset: assets/fonts/Lato/Lato-Bold.ttf
-          weight: 700 
+          weight: 700
         - asset: assets/fonts/Lato/Lato-SemiBold.ttf
           weight: 600
 
 flutter_gen:
   output: lib/theme/
-  line_length: 120 
+  line_length: 120
 
   integrations:
     flutter_svg: true

--- a/test/scan_bloc_test.dart
+++ b/test/scan_bloc_test.dart
@@ -12,7 +12,7 @@ import 'package:pola_flutter/pages/scan/scan_vibration.dart';
 import 'package:pola_flutter/pages/scan/torch_controller.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:test/test.dart';
-
+import 'package:flutter/foundation.dart';
 import 'analytics/mock_analytics_provider.dart';
 
 void main() {
@@ -27,9 +27,7 @@ void main() {
       'toggle torch',
       build: () => _scanBloc(),
       act: (bloc) => bloc.add(ScanEvent.torchSwitched()),
-      expect: () => [
-        ScanState(isTorchOn: true),
-      ],
+      expect: () => [ScanState(isTorchOn: true)],
     );
 
     blocTest(
@@ -38,7 +36,7 @@ void main() {
       act: (bloc) => bloc.add(ScanEvent.barcodeScanned("5900311000360")),
       expect: () => [
         ScanState(isLoading: true),
-        ScanState(list: [_testSearchResult], isLoading: false)
+        ScanState(list: [_testSearchResult], isLoading: false),
       ],
     );
 
@@ -49,9 +47,10 @@ void main() {
       expect: () => [
         ScanState(isLoading: true),
         ScanState(
-            list: [_testSearchResultWithButton("button1")],
-            isLoading: false,
-            remoteButtonState: _remoteStateButton("button1"))
+          list: [_testSearchResultWithButton("button1")],
+          isLoading: false,
+          remoteButtonState: _remoteStateButton("button1"),
+        ),
       ],
     );
 
@@ -65,14 +64,16 @@ void main() {
       expect: () => [
         ScanState(isLoading: true),
         ScanState(
-            list: [_testSearchResultWithButton("button1")],
-            isLoading: false,
-            remoteButtonState: _remoteStateButton("button1")),
+          list: [_testSearchResultWithButton("button1")],
+          isLoading: false,
+          remoteButtonState: _remoteStateButton("button1"),
+        ),
         ScanState(
-            list: [_testSearchResultWithButton("button1")],
-            isLoading: false,
-            remoteButtonState: null,
-            wasRemoteButtonClosed: true),
+          list: [_testSearchResultWithButton("button1")],
+          isLoading: false,
+          remoteButtonState: null,
+          wasRemoteButtonClosed: true,
+        ),
       ],
     );
 
@@ -87,27 +88,31 @@ void main() {
       expect: () => [
         ScanState(isLoading: true),
         ScanState(
-            list: [_testSearchResultWithButton("button1")],
-            isLoading: false,
-            remoteButtonState: _remoteStateButton("button1")),
+          list: [_testSearchResultWithButton("button1")],
+          isLoading: false,
+          remoteButtonState: _remoteStateButton("button1"),
+        ),
         ScanState(
-            list: [_testSearchResultWithButton("button1")],
-            isLoading: false,
-            remoteButtonState: null,
-            wasRemoteButtonClosed: true),
+          list: [_testSearchResultWithButton("button1")],
+          isLoading: false,
+          remoteButtonState: null,
+          wasRemoteButtonClosed: true,
+        ),
         ScanState(
-            list: [_testSearchResultWithButton("button1")],
-            isLoading: true,
-            remoteButtonState: null,
-            wasRemoteButtonClosed: true),
+          list: [_testSearchResultWithButton("button1")],
+          isLoading: true,
+          remoteButtonState: null,
+          wasRemoteButtonClosed: true,
+        ),
         ScanState(
-            list: [
-              _testSearchResultWithButton("button1"),
-              _testSearchResultWithButton("button2")
-            ],
-            isLoading: false,
-            remoteButtonState: null,
-            wasRemoteButtonClosed: true),
+          list: [
+            _testSearchResultWithButton("button1"),
+            _testSearchResultWithButton("button2"),
+          ],
+          isLoading: false,
+          remoteButtonState: null,
+          wasRemoteButtonClosed: true,
+        ),
       ],
     );
 
@@ -117,7 +122,7 @@ void main() {
       act: (bloc) => bloc.add(ScanEvent.barcodeScanned("0")),
       expect: () => [
         ScanState(isLoading: true),
-        ScanState(isLoading: false, isError: true)
+        ScanState(isLoading: false, isError: true),
       ],
     );
 
@@ -132,62 +137,71 @@ void main() {
       'emits state with empty list when reset scanned companies button tapped',
       build: () => _scanBloc(state: ScanState(list: [_testSearchResult])),
       act: (bloc) => bloc.add(ScanEvent.resetScannedCompaniesButton()),
-      expect: () => [
-        ScanState(list: [])
-      ],
+      expect: () => [ScanState(list: [])],
     );
   });
 }
 
 ScanBloc _scanBloc({ScanState state = const ScanState()}) {
-  return ScanBloc(_MockPolaApi(), _MockScanVibration(),
-      PolaAnalytics(provider: MockAnalyticsProvider()), _MockTorchController(),
-      state: state);
+  return ScanBloc(
+    _MockPolaApi(),
+    _MockScanVibration(),
+    PolaAnalytics(provider: MockAnalyticsProvider()),
+    _MockTorchController(),
+    state: state,
+  );
 }
 
 var _testSearchResult = SearchResult(
-    productId: 5900311000360,
-    code: "code",
-    name: "name",
+  productId: 5900311000360,
+  code: "code",
+  name: "name",
+  cardType: "card",
+  companies: [],
+  report: null,
+  donate: Donate(
+    showButton: false,
+    url: "https://klubjagiellonski.pl/zbiorka/wspieraj-aplikacje-pola/",
+    title: "Pomóż aplikacji Pola",
+  ),
+);
+
+SearchResult _testSearchResultWithButton(String code) {
+  return SearchResult(
+    productId: 6262330,
+    code: code,
+    name: "Miejsce rejestracji: Francja",
     cardType: "card",
     companies: [],
     report: null,
     donate: Donate(
-        showButton: false,
-        url: "https://klubjagiellonski.pl/zbiorka/wspieraj-aplikacje-pola/",
-        title: "Pomóż aplikacji Pola"));
-
-SearchResult _testSearchResultWithButton(String code) {
-  return SearchResult(
-      productId: 6262330,
-      code: code,
-      name: "Miejsce rejestracji: Francja",
-      cardType: "card",
-      companies: [],
-      report: null,
-      donate: Donate(
-          showButton: true,
-          url: "https://klubjagiellonski.pl/zbiorka/wspieraj-aplikacje-pola/",
-          title: "Pomóż aplikacji Pola"));
+      showButton: true,
+      url: "https://klubjagiellonski.pl/zbiorka/wspieraj-aplikacje-pola/",
+      title: "Pomóż aplikacji Pola",
+    ),
+  );
 }
 
-RemoteButtonState _remoteStateButton(code) {
+RemoteButtonState _remoteStateButton(String code) {
   return RemoteButtonState(
-      title: "Pomóż aplikacji Pola",
-      uri: Uri.parse(
-          "https://klubjagiellonski.pl/zbiorka/wspieraj-aplikacje-pola/"),
-      code: code);
+    title: "Pomóż aplikacji Pola",
+    uri: Uri.parse(
+      "https://klubjagiellonski.pl/zbiorka/wspieraj-aplikacje-pola/",
+    ),
+    code: code,
+  );
 }
 
 class _MockPolaApi extends PolaApi {
   @override
   Future<ApiResponse<SearchResult>> getCompany(String code) {
-    print("MockPolaApi getCompany " + code.toString());
+    debugPrint("MockPolaApi getCompany ${code.toString()}");
     if (code == "5900311000360") {
       return Future.value(ApiResponse.completed(_testSearchResult));
     } else if (code == "button1" || code == "button2") {
       return Future.value(
-          ApiResponse.completed(_testSearchResultWithButton(code)));
+        ApiResponse.completed(_testSearchResultWithButton(code)),
+      );
     } else {
       return Future.value(ApiResponse.error("error"));
     }


### PR DESCRIPTION
- Dodałem `analysis_options.yaml` w root projektu oraz `flutter_lints`, bo Flutter rekomenduje używanie pakietu [`flutter_lints`](https://docs.flutter.dev/release/breaking-changes/flutter-lints-package) dla aplikacji Flutter. Dart analyzer oczekuje pliku [`analysis_options.yaml`](https://dart.dev/tools/analysis#the-analysis-options-file) obok `pubspec.yaml`.

- Wykluczyłem `build/**` i pliki generowane (`*.g.dart`, `*.freezed.dart`, `*.chopper.dart`, `*.gen.dart`), bo Dart analyzer wspiera [`analyzer.exclude`](https://dart.dev/tools/analysis#excluding-files), a dokumentacja wskazuje wygenerowany kod jako typowy przypadek, który można wyłączyć z analizy.

- Poprawiłem konstruktory widgetów i modeli zgodnie z regułami:
  [`use_key_in_widget_constructors`](https://dart.dev/tools/linter-rules/use_key_in_widget_constructors),
  [`use_super_parameters`](https://dart.dev/tools/linter-rules/use_super_parameters),
  [`prefer_const_constructors_in_immutables`](https://dart.dev/tools/linter-rules/prefer_const_constructors_in_immutables).

- Zamieniłem `print` na `debugPrint` / logging, bo `flutter_lints` włącza regułę [`avoid_print`](https://dart.dev/tools/linter-rules/avoid_print), która odradza `print` w kodzie produkcyjnym.

- Dodałem `logging` jako bezpośrednią zależność, ponieważ kod importuje `package:logging/logging.dart`, a reguła [`depend_on_referenced_packages`](https://dart.dev/tools/linter-rules/depend_on_referenced_packages) wymaga deklarowania bezpośrednio importowanych paczek w `pubspec.yaml`.

- Uporządkowałem składnię i czytelność zgodnie z regułami:
  [`prefer_null_aware_operators`](https://dart.dev/tools/linter-rules/prefer_null_aware_operators),
  [`prefer_interpolation_to_compose_strings`](https://dart.dev/tools/linter-rules/prefer_interpolation_to_compose_strings),
  [`unnecessary_new`](https://dart.dev/tools/linter-rules/unnecessary_new),
  [`unnecessary_this`](https://dart.dev/tools/linter-rules/unnecessary_this),
  [`unnecessary_underscores`](https://dart.dev/tools/linter-rules/unnecessary_underscores).

- Poprawiłem układ argumentów widgetów i kontenery używane tylko do odstępu zgodnie z:
  [`sort_child_properties_last`](https://dart.dev/tools/linter-rules/sort_child_properties_last),
  [`sized_box_for_whitespace`](https://dart.dev/tools/linter-rules/sized_box_for_whitespace).

- Poprawiłem miejsca związane z publicznym API i typowaniem:
  [`library_private_types_in_public_api`](https://dart.dev/tools/linter-rules/library_private_types_in_public_api),
  [`strict_top_level_inference`](https://dart.dev/tools/linter-rules/strict_top_level_inference),
  [`constant_identifier_names`](https://dart.dev/tools/linter-rules/constant_identifier_names).

- Poprawiłem użycie `BuildContext` po operacjach asynchronicznych zgodnie z regułą [`use_build_context_synchronously`](https://dart.dev/tools/linter-rules/use_build_context_synchronously).

Przetestowałem kod w środowiskach prod, qa i dev