### PR TITLE
Stałe URL constants

### DIFF
--- a/lib/config/app_urls.dart
+++ b/lib/config/app_urls.dart
@@ -1,0 +1,21 @@
+abstract final class AppUrls {
+  static const polaBase = 'https://www.pola-app.pl';
+
+  static const apiBase = polaBase;
+  static const aboutPola = '$polaBase/m/about';
+  static const search = '$polaBase/m/search/';
+  static const news = '$polaBase/m/blog/';
+  static const method = '$polaBase/m/method';
+  static const partners = '$polaBase/m/partners';
+  static const friends = '$polaBase/m/friends';
+  static const team = '$polaBase/m/team';
+
+  static const clubAbout =
+      'https://klubjagiellonski.pl/o-klubie-jagiellonskim/';
+  static const github = 'https://github.com/KlubJagiellonski';
+  static const twitter = 'https://x.com/pola_app';
+  static const facebook = 'https://www.facebook.com/share/1EVVFxN1Qn/';
+  static const appStore = 'https://apps.apple.com/app/id1038401148';
+  static const playStore =
+      'https://play.google.com/store/apps/details?id=pl.pola_app';
+}

--- a/lib/data/pola_api_service.dart
+++ b/lib/data/pola_api_service.dart
@@ -1,4 +1,5 @@
 ﻿import 'package:chopper/chopper.dart';
+import 'package:pola_flutter/config/app_urls.dart';
 part 'pola_api_service.chopper.dart';
 
 @ChopperApi()
@@ -6,21 +7,22 @@ abstract class PolaApiService extends ChopperService {
   //example code 5900311000360
   @GET(path: 'a/v4/get_by_code')
   Future<Response> getCompany(
-      @Query("code") String code, @Query("device_id") String deviceId);
+    @Query("code") String code,
+    @Query("device_id") String deviceId,
+  );
 
   @POST(path: 'a/v4/create_report')
   Future<Response> createReport(
-      @Query("device_id") String deviceId,
-      @Body() Map<String, dynamic> body);
+    @Query("device_id") String deviceId,
+    @Body() Map<String, dynamic> body,
+  );
 
   static PolaApiService create() {
     final client = ChopperClient(
-      baseUrl: Uri.parse('https://www.pola-app.pl'),
+      baseUrl: Uri.parse(AppUrls.apiBase),
       interceptors: [HttpLoggingInterceptor()],
       converter: JsonConverter(),
-      services: [
-        _$PolaApiService(),
-      ],
+      services: [_$PolaApiService()],
     );
     return _$PolaApiService(client);
   }

--- a/lib/pages/detail/friends_bar.dart
+++ b/lib/pages/detail/friends_bar.dart
@@ -5,6 +5,7 @@ import 'package:pola_flutter/theme/fonts.gen.dart';
 import 'package:pola_flutter/theme/text_size.dart';
 import 'package:pola_flutter/ui/web_view_dialog.dart';
 import 'package:pola_flutter/i18n/strings.g.dart';
+import 'package:pola_flutter/config/app_urls.dart';
 
 class FriendsBar extends StatelessWidget {
   const FriendsBar({super.key});
@@ -17,7 +18,7 @@ class FriendsBar extends StatelessWidget {
         onTap: () {
           showWebViewDialog(
             context: context,
-            url: "https://www.pola-app.pl/m/friends",
+            url: AppUrls.friends,
             title: t.companyScreen.polaFriends,
           );
         },

--- a/lib/pages/menu/menu_item_list_view.dart
+++ b/lib/pages/menu/menu_item_list_view.dart
@@ -8,6 +8,7 @@ import 'package:pola_flutter/analytics/analytics_about_row.dart';
 import 'package:pola_flutter/analytics/pola_analytics.dart';
 import 'package:pola_flutter/i18n/strings.g.dart';
 import '../../ui/web_view_dialog.dart';
+import 'package:pola_flutter/config/app_urls.dart';
 
 class MenuItemListView extends StatelessWidget {
   final PolaAnalytics analytics;
@@ -24,56 +25,54 @@ class MenuItemListView extends StatelessWidget {
           text: t.menu.aboutPola,
           icon: Assets.menuPage.info.svg(),
           analyticsRow: AnalyticsAboutRow.aboutPola,
-          url: 'https://www.pola-app.pl/m/about',
+          url: AppUrls.aboutPola,
         ),
         _webViewItem(
           context: context,
           text: t.menu.aboutClub,
           icon: Assets.menuPage.info.svg(),
           analyticsRow: AnalyticsAboutRow.aboutKJ,
-          url: 'https://klubjagiellonski.pl/o-klubie-jagiellonskim/',
+          url: AppUrls.clubAbout,
         ),
         _webViewItem(
           context: context,
           text: t.menu.instruction,
           icon: Assets.menuPage.thumbs.svg(),
           analyticsRow: AnalyticsAboutRow.instructionSet,
-          url: 'https://www.pola-app.pl/m/method',
+          url: AppUrls.method,
         ),
         _webViewItem(
           context: context,
           text: t.menu.partners,
           icon: Assets.menuPage.handshake.svg(),
           analyticsRow: AnalyticsAboutRow.partners,
-          url: 'https://www.pola-app.pl/m/partners',
+          url: AppUrls.partners,
         ),
         _webViewItem(
           context: context,
           text: t.menu.polasFriends,
           icon: Assets.menuPage.diversity.svg(),
           analyticsRow: AnalyticsAboutRow.polasFriends,
-          url: 'https://www.pola-app.pl/m/friends',
+          url: AppUrls.friends,
         ),
         _externalUrlItem(
           text: t.menu.rateUS,
-          icon: Assets.menuPage.star.svg(), 
+          icon: Assets.menuPage.star.svg(),
           analyticsRow: AnalyticsAboutRow.rateUs,
-          url: Platform.isIOS
-              ? "https://apps.apple.com/app/id1038401148"
-              : "https://play.google.com/store/apps/details?id=pl.pola_app",
+          url: Platform.isIOS ? AppUrls.appStore : AppUrls.playStore,
         ),
         _webViewItem(
           context: context,
           text: t.menu.team,
           icon: Assets.menuPage.groups.svg(),
           analyticsRow: AnalyticsAboutRow.team,
-          url: 'https://www.pola-app.pl/m/team',
+          url: AppUrls.team,
         ),
         _externalUrlItem(
           text: "Github",
           icon: Assets.menuPage.github.svg(),
           analyticsRow: AnalyticsAboutRow.github,
-          url: 'https://github.com/KlubJagiellonski',
+          url: AppUrls.github,
         ),
       ],
     );
@@ -113,10 +112,7 @@ class MenuItemListView extends StatelessWidget {
   }
 
   void _launchURL(String url) async {
-    launchUrl(
-      Uri.parse(url),
-      mode: LaunchMode.externalApplication,
-    );
+    launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
   }
 }
 
@@ -132,7 +128,10 @@ class _MenuBottomItem extends StatelessWidget {
   });
 
   final textStyle = const TextStyle(
-      fontWeight: FontWeight.w500, fontSize: TextSize.mediumTitle, fontFamily: FontFamily.lato);
+    fontWeight: FontWeight.w500,
+    fontSize: TextSize.mediumTitle,
+    fontFamily: FontFamily.lato,
+  );
 
   @override
   Widget build(BuildContext context) {

--- a/lib/pages/menu/social_media_list_view.dart
+++ b/lib/pages/menu/social_media_list_view.dart
@@ -6,6 +6,7 @@ import 'package:pola_flutter/theme/fonts.gen.dart';
 import 'package:pola_flutter/theme/text_size.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:pola_flutter/i18n/strings.g.dart';
+import 'package:pola_flutter/config/app_urls.dart';
 
 class SocialMediaListView extends StatelessWidget {
   final PolaAnalytics analytics;
@@ -25,7 +26,7 @@ class SocialMediaListView extends StatelessWidget {
               style: TextStyle(
                 fontSize: TextSize.smallTitle,
                 fontWeight: FontWeight.w700,
-                fontFamily: FontFamily.lato
+                fontFamily: FontFamily.lato,
               ),
             ),
           ],
@@ -44,13 +45,13 @@ class SocialMediaListView extends StatelessWidget {
                       _socialItem(
                         text: "X (Twitter)",
                         analyticsRow: AnalyticsAboutRow.twitter,
-                        url: 'https://twitter.com/pola_app',
+                        url: AppUrls.twitter,
                       ),
                       const SizedBox(width: 14.0),
                       _socialItem(
                         text: "Facebook",
                         analyticsRow: AnalyticsAboutRow.facebook,
-                        url: 'https://www.facebook.com/share/1EVVFxN1Qn/',
+                        url: AppUrls.facebook,
                       ),
                     ],
                   ),
@@ -78,10 +79,7 @@ class SocialMediaListView extends StatelessWidget {
   }
 
   void _launchURL(String url) async {
-    await launchUrl(
-      Uri.parse(url),
-      mode: LaunchMode.externalApplication,
-    );
+    await launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
   }
 }
 

--- a/lib/pages/scan/scan.dart
+++ b/lib/pages/scan/scan.dart
@@ -21,6 +21,7 @@ import 'package:pola_flutter/theme/colors.dart';
 import 'package:pola_flutter/theme/text_size.dart';
 import 'package:pola_flutter/ui/menu_icon_button.dart';
 import 'package:pola_flutter/ui/web_view_dialog.dart';
+import 'package:pola_flutter/config/app_urls.dart';
 
 class MainPage extends StatefulWidget {
   final RouteObserver<ModalRoute<dynamic>> routeObserver;
@@ -103,7 +104,7 @@ class MainPageState extends State<MainPage> with RouteAware {
             _analytics.aboutPolaOpened();
             showWebViewDialog(
               context: context,
-              url: "https://www.pola-app.pl/m/about",
+              url: AppUrls.aboutPola,
               title: t.menu.aboutPola,
             );
           },

--- a/lib/pages/scan/scan_navigator.dart
+++ b/lib/pages/scan/scan_navigator.dart
@@ -6,6 +6,7 @@ import 'package:pola_flutter/pages/dialpad/dialpad.dart';
 import 'package:pola_flutter/pages/report/report_page.dart';
 import 'package:pola_flutter/pages/scan/scan.dart';
 import 'package:pola_flutter/ui/web_view_tab.dart';
+import 'package:pola_flutter/config/app_urls.dart';
 
 class ScanNavigator extends StatefulWidget {
   final GlobalKey<NavigatorState>? navigatorKey;
@@ -96,7 +97,7 @@ class _ScanNavigatorState extends State<ScanNavigator> {
         return MaterialPageRoute(
           builder: (context) => WebViewTab(
             title: Translations.of(context).search.title,
-            url: "https://www.pola-app.pl/m/search/",
+            url: AppUrls.search,
           ),
         );
       case '/report':

--- a/lib/pola_tab_controller.dart
+++ b/lib/pola_tab_controller.dart
@@ -6,6 +6,7 @@ import 'package:pola_flutter/pages/scan/scan_navigator.dart';
 import 'package:pola_flutter/pages/web/web_view_page.dart';
 import 'package:pola_flutter/theme/assets.gen.dart';
 import 'package:pola_flutter/ui/web_view_tab.dart';
+import 'package:pola_flutter/config/app_urls.dart';
 
 class PolaTabController extends StatefulWidget {
   const PolaTabController({super.key});
@@ -55,7 +56,7 @@ class _PolaTabControllerState extends State<PolaTabController> {
     ),
     WebViewTab(
       title: t.news.title,
-      url: "https://www.pola-app.pl/m/blog/",
+      url: AppUrls.news,
       pageKey: _newsWebViewPageKey,
     ),
   ];


### PR DESCRIPTION
Porządkuje stałe URL używane w aplikacji przez przeniesienie ich do wspólnego pliku.`AppUrls` pełni wyłącznie rolę namespace’a dla stałych `static const`. `abstract final class komunikuje, że tej klasy nie należy tworzyć, rozszerzać ani implementować.

Dzięki temu nie trzeba dodawać sztucznego prywatnego konstruktora typu  `AppUrls._()`

- dodano centralne miejsce na adresy URL aplikacji
- zastąpiono hardcodowane linki w widokach menu, skanera, aktualności i konfiguracji API
- bez zmian w logice działania aplikacji

przetestowano na QA/Prod/Dev