### PR TITLE
Add MultiRepositoryProvider for DI

### DIFF
--- a/lib/data/pola_api_repository.dart
+++ b/lib/data/pola_api_repository.dart
@@ -8,32 +8,30 @@ import 'package:pola_flutter/models/search_result.dart';
 
 abstract class PolaApi {
   Future<ApiResponse<SearchResult>> getCompany(String code);
-  Future<bool> createReport({
-    required String description,
-    int? productId,
-  });
+  Future<bool> createReport({required String description, int? productId});
 }
 
 class PolaApiRepository implements PolaApi {
-  late final PolaApiService _polaApiService;
-  late final DeviceIdService _deviceIdService;
+  final PolaApiService _polaApiService;
+  final DeviceIdService _deviceIdService;
 
-  PolaApiRepository(){
-    _polaApiService = PolaApiService.create();
-    DeviceIdService.create().then((value) => _deviceIdService = value);
-  }
+  PolaApiRepository({
+    required DeviceIdService deviceIdService,
+    PolaApiService? polaApiService,
+  }) : _deviceIdService = deviceIdService,
+       _polaApiService = polaApiService ?? PolaApiService.create();
 
   @override
   Future<ApiResponse<SearchResult>> getCompany(String code) async {
     SearchResult? result;
     Response response;
-    try{
+    try {
       response = await _polaApiService.getCompany(code, _deviceIdService.uuid);
-    }on SocketException catch (exception){
+    } on SocketException catch (exception) {
       return ApiResponse.error(exception.message);
     }
 
-    if(response.isSuccessful){
+    if (response.isSuccessful) {
       result = SearchResult.fromJson(response.body as Map<String, dynamic>);
       return ApiResponse<SearchResult>.completed(result);
     }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,10 +3,14 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:pola_flutter/analytics/pola_analytics.dart';
 import 'package:pola_flutter/config/firebase_config.dart';
+import 'package:pola_flutter/data/device_id_service.dart';
+import 'package:pola_flutter/data/pola_api_repository.dart';
 import 'package:pola_flutter/i18n/strings.g.dart';
 import 'package:pola_flutter/pola_tab_controller.dart';
 import 'package:pola_flutter/firebase_options.dart';
+import 'package:pola_flutter/pages/scan/scan_vibration.dart';
 import 'package:pola_flutter/ui/flavor_banner.dart';
 import 'package:logging/logging.dart' as logging;
 
@@ -26,11 +30,27 @@ void main() async {
       options: DefaultFirebaseOptions.currentPlatform,
     );
   }
-  runApp(PolaApp());
+  final deviceIdService = await DeviceIdService.create();
+  runApp(
+    PolaApp(
+      polaApi: PolaApiRepository(deviceIdService: deviceIdService),
+      analytics: PolaAnalytics.instance(),
+      scanVibration: ScanVibrationImpl(),
+    ),
+  );
 }
 
 class PolaApp extends StatelessWidget {
-  const PolaApp({super.key});
+  final PolaApi polaApi;
+  final PolaAnalytics analytics;
+  final ScanVibration scanVibration;
+
+  const PolaApp({
+    super.key,
+    required this.polaApi,
+    required this.analytics,
+    required this.scanVibration,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -38,13 +58,20 @@ class PolaApp extends StatelessWidget {
       DeviceOrientation.portraitUp,
       DeviceOrientation.portraitDown,
     ]);
-    return TranslationProvider(
-      child: MaterialApp(
-        debugShowCheckedModeBanner: false,
-        theme: ThemeData(
-          colorScheme: ColorScheme.light().copyWith(primary: Colors.red),
+    return MultiRepositoryProvider(
+      providers: [
+        RepositoryProvider<PolaApi>.value(value: polaApi),
+        RepositoryProvider<PolaAnalytics>.value(value: analytics),
+        RepositoryProvider<ScanVibration>.value(value: scanVibration),
+      ],
+      child: TranslationProvider(
+        child: MaterialApp(
+          debugShowCheckedModeBanner: false,
+          theme: ThemeData(
+            colorScheme: ColorScheme.light().copyWith(primary: Colors.red),
+          ),
+          home: FlavorBanner(flavor: _appFlavor, child: PolaTabController()),
         ),
-        home: FlavorBanner(flavor: _appFlavor, child: PolaTabController()),
       ),
     );
   }

--- a/lib/pages/detail/logotypes.dart
+++ b/lib/pages/detail/logotypes.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:pola_flutter/analytics/pola_analytics.dart';
 import 'package:pola_flutter/models/search_result.dart';
 import 'package:pola_flutter/theme/colors.dart';
@@ -14,9 +15,12 @@ class Logotype {
 class Logotypes extends StatelessWidget {
   final List<Logotype> logotypes;
   final SearchResult searchResult;
-  final PolaAnalytics analytics = PolaAnalytics.instance();
 
-  Logotypes({super.key, required this.logotypes, required this.searchResult});
+  const Logotypes({
+    super.key,
+    required this.logotypes,
+    required this.searchResult,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -34,7 +38,7 @@ class Logotypes extends StatelessWidget {
               final Uri? uri = Uri.tryParse(url);
               if (uri == null) return;
 
-              analytics.readMore(searchResult, url);
+              context.read<PolaAnalytics>().readMore(searchResult, url);
               launchUrl(uri, mode: LaunchMode.externalApplication);
             },
             child: Padding(

--- a/lib/pages/detail/replacement/replacements_section.dart
+++ b/lib/pages/detail/replacement/replacements_section.dart
@@ -34,8 +34,8 @@ class ReplacementsSection extends StatelessWidget {
 
     return BlocProvider(
       create: (context) => ReplacementBloc(
-        PolaApiRepository(),
-        PolaAnalytics.instance(),
+        context.read<PolaApi>(),
+        context.read<PolaAnalytics>(),
         state: ReplacementState(productCode: productCode),
       ),
       child: BlocListener<ReplacementBloc, ReplacementState>(

--- a/lib/pages/report/report_page.dart
+++ b/lib/pages/report/report_page.dart
@@ -32,8 +32,8 @@ class _ReportPageState extends State<ReportPage> {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (_) =>
-          ReportBloc(PolaApiRepository(), productId: widget.productId),
+      create: (context) =>
+          ReportBloc(context.read<PolaApi>(), productId: widget.productId),
       child: BlocConsumer<ReportBloc, ReportState>(
         listenWhen: (prev, curr) =>
             prev.requestState != ReportRequestState.success &&

--- a/lib/pages/scan/companies_list.dart
+++ b/lib/pages/scan/companies_list.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:pola_flutter/analytics/pola_analytics.dart';
 import 'package:pola_flutter/i18n/strings.g.dart';
 import 'package:pola_flutter/pages/scan/scan_state.dart';
@@ -7,7 +8,7 @@ import 'package:pola_flutter/ui/list_item.dart';
 import 'dart:math';
 
 class CompaniesList extends StatelessWidget {
-  CompaniesList({
+  const CompaniesList({
     super.key,
     required this.state,
     required this.listScrollController,
@@ -17,7 +18,6 @@ class CompaniesList extends StatelessWidget {
   final ScanState state;
   final ScrollController listScrollController;
   final GestureTapCallback onCloseRemoteButtonTap;
-  final PolaAnalytics _analytics = PolaAnalytics.instance();
 
   @override
   Widget build(BuildContext context) {
@@ -47,7 +47,7 @@ class CompaniesList extends StatelessWidget {
                   child: ResultListItem(searchResult: state.list[index]),
                   onTap: () {
                     final result = state.list[index];
-                    _analytics.opensCard(result);
+                    context.read<PolaAnalytics>().opensCard(result);
                     Navigator.pushNamed(context, '/detail', arguments: result);
                   },
                 );

--- a/lib/pages/scan/remote_button.dart
+++ b/lib/pages/scan/remote_button.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:pola_flutter/analytics/pola_analytics.dart';
 import 'package:pola_flutter/theme/assets.gen.dart';
 import 'package:pola_flutter/theme/colors.dart';
@@ -53,7 +54,7 @@ class RemoteButton extends StatelessWidget {
                   foregroundColor: WidgetStateProperty.all<Color>(Colors.white),
                 ),
                 onPressed: () async {
-                  PolaAnalytics.instance().donateOpened(state.code);
+                  context.read<PolaAnalytics>().donateOpened(state.code);
                   await launchUrl(
                     state.uri,
                     mode: LaunchMode.externalApplication,

--- a/lib/pages/scan/scan.dart
+++ b/lib/pages/scan/scan.dart
@@ -42,7 +42,6 @@ class MainPageState extends State<MainPage> with RouteAware {
     detectionSpeed: DetectionSpeed.normal,
     formats: [BarcodeFormat.ean13, BarcodeFormat.ean8],
   );
-  final PolaAnalytics _analytics = PolaAnalytics.instance();
   bool _childRoutePushed = false;
 
   ScrollController listScrollController = ScrollController();
@@ -50,10 +49,11 @@ class MainPageState extends State<MainPage> with RouteAware {
   @override
   void initState() {
     super.initState();
+    final analytics = context.read<PolaAnalytics>();
     _scanBloc = ScanBloc(
-      PolaApiRepository(),
-      ScanVibrationImpl(),
-      _analytics,
+      context.read<PolaApi>(),
+      context.read<ScanVibration>(),
+      analytics,
       TorchControllerImpl(cameraController: cameraController),
     );
     widget.scanTabActive.addListener(_onScanTabActiveChanged);
@@ -94,13 +94,15 @@ class MainPageState extends State<MainPage> with RouteAware {
 
   @override
   Widget build(BuildContext context) {
+    final analytics = context.read<PolaAnalytics>();
+
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Colors.transparent,
         elevation: 0,
         leading: IconButton(
           onPressed: () {
-            _analytics.aboutPolaOpened();
+            analytics.aboutPolaOpened();
             showWebViewDialog(
               context: context,
               url: "https://www.pola-app.pl/m/about",
@@ -132,7 +134,7 @@ class MainPageState extends State<MainPage> with RouteAware {
                 horizontal: 16.0,
               ),
               child: Column(
-                children: <Widget>[ScanSearchButton(analytics: _analytics)],
+                children: <Widget>[ScanSearchButton(analytics: analytics)],
               ),
             ),
           ),
@@ -249,6 +251,8 @@ class MainPageState extends State<MainPage> with RouteAware {
   void dispose() {
     widget.scanTabActive.removeListener(_onScanTabActiveChanged);
     widget.routeObserver.unsubscribe(this);
+    _scanBloc.close();
+    listScrollController.dispose();
     cameraController.dispose();
     super.dispose();
   }

--- a/lib/pola_tab_controller.dart
+++ b/lib/pola_tab_controller.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:pola_flutter/analytics/analytics_main_tab.dart';
 import 'package:pola_flutter/analytics/pola_analytics.dart';
 import 'package:pola_flutter/i18n/strings.g.dart';
@@ -16,7 +17,6 @@ class PolaTabController extends StatefulWidget {
 
 class _PolaTabControllerState extends State<PolaTabController> {
   int _selectedIndex = 0;
-  final _analytics = PolaAnalytics.instance();
   final _scanNavigatorKey = GlobalKey<NavigatorState>();
   final _newsWebViewPageKey = GlobalKey<WebViewPageState>();
 
@@ -89,7 +89,7 @@ class _PolaTabControllerState extends State<PolaTabController> {
           break;
       }
     } else {
-      _analytics.mainTabChanged(_getTabParameter(index));
+      context.read<PolaAnalytics>().mainTabChanged(_getTabParameter(index));
       setState(() {
         _selectedIndex = index;
       });

--- a/lib/ui/menu_icon_button.dart
+++ b/lib/ui/menu_icon_button.dart
@@ -1,33 +1,34 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:pola_flutter/analytics/analytics_about_row.dart';
 import 'package:pola_flutter/analytics/pola_analytics.dart';
 import 'package:pola_flutter/pages/menu/menu_bottom_sheet.dart';
 import 'package:pola_flutter/theme/assets.gen.dart';
 
 class MenuIconButton extends StatelessWidget {
-  final PolaAnalytics _analytics = PolaAnalytics.instance();
   final Color color;
 
-  MenuIconButton({super.key, required this.color});
+  const MenuIconButton({super.key, required this.color});
 
   @override
   Widget build(BuildContext context) {
     return IconButton(
       onPressed: () {
-        _analytics.aboutOpened(AnalyticsAboutRow.menu);
+        final analytics = context.read<PolaAnalytics>();
+        analytics.aboutOpened(AnalyticsAboutRow.menu);
         showModalBottomSheet<void>(
           backgroundColor: Colors.transparent,
           isScrollControlled: true,
           context: context,
           useRootNavigator: true,
           builder: (BuildContext context) {
-            return MenuBottomSheet(analytics: _analytics);
-          }
+            return MenuBottomSheet(analytics: analytics);
+          },
         );
       },
       icon: Assets.menuPage.menu.svg(
-        colorFilter: ColorFilter.mode(color, BlendMode.srcIn)
-        ),
+        colorFilter: ColorFilter.mode(color, BlendMode.srcIn),
+      ),
     );
   }
 }


### PR DESCRIPTION

- Dodano `MultiRepositoryProvider` w [main.dart](/Users/janbiernacki/Dev/PolaDev/pola-flutter/lib/main.dart:61), który udostępnia `PolaApi`, `PolaAnalytics` i `ScanVibration`.
- Zmieniono [PolaApiRepository](/Users/janbiernacki/Dev/PolaDev/pola-flutter/lib/data/pola_api_repository.dart:18), żeby przyjmował gotowy `DeviceIdService` przez konstruktor zamiast inicjalizować go asynchronicznie wewnątrz konstruktora.
- `ScanBloc`, `ReportBloc` i `ReplacementBloc` pobierają teraz zależności przez `context.read<T>()` w [scan.dart](/Users/janbiernacki/Dev/PolaDev/pola-flutter/lib/pages/scan/scan.dart:50), [report_page.dart](/Users/janbiernacki/Dev/PolaDev/pola-flutter/lib/pages/report/report_page.dart:34) i [replacements_section.dart](/Users/janbiernacki/Dev/PolaDev/pola-flutter/lib/pages/detail/replacement/replacements_section.dart:35).
- Usunięto bezpośrednie użycia `PolaAnalytics.instance()` z widgetów takich jak [pola_tab_controller.dart](/Users/janbiernacki/Dev/PolaDev/pola-flutter/lib/pola_tab_controller.dart:92), [companies_list.dart](/Users/janbiernacki/Dev/PolaDev/pola-flutter/lib/pages/scan/companies_list.dart:50), [remote_button.dart](/Users/janbiernacki/Dev/PolaDev/pola-flutter/lib/pages/scan/remote_button.dart:57), [logotypes.dart](/Users/janbiernacki/Dev/PolaDev/pola-flutter/lib/pages/detail/logotypes.dart:41) i [menu_icon_button.dart](/Users/janbiernacki/Dev/PolaDev/pola-flutter/lib/ui/menu_icon_button.dart:17).
- Dodano domykanie ręcznie tworzonego `ScanBloc` i `ScrollController` w ekranie skanowania.

przetestowane na QA/Prod/Dev