### PR TITLE
Refactor Webview Search to Native

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -300,7 +300,7 @@ SPEC CHECKSUMS:
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
-  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
+  url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
   vibration: 69774ad57825b11c951ee4c46155f455d7a592ce
   webview_flutter_wkwebview: 8ebf4fded22593026f7dbff1fbff31ea98573c8d
 

--- a/lib/data/pola_api_repository.dart
+++ b/lib/data/pola_api_repository.dart
@@ -4,10 +4,15 @@ import 'package:chopper/chopper.dart';
 import 'package:pola_flutter/data/api_response.dart';
 import 'package:pola_flutter/data/pola_api_service.dart';
 import 'package:pola_flutter/data/device_id_service.dart';
+import 'package:pola_flutter/models/product_search_response.dart';
 import 'package:pola_flutter/models/search_result.dart';
 
 abstract class PolaApi {
   Future<ApiResponse<SearchResult>> getCompany(String code);
+  Future<ApiResponse<ProductSearchResponse>> searchProducts(
+    String query, {
+    String? pageToken,
+  });
   Future<bool> createReport({required String description, int? productId});
 }
 
@@ -34,6 +39,31 @@ class PolaApiRepository implements PolaApi {
     if (response.isSuccessful) {
       result = SearchResult.fromJson(response.body as Map<String, dynamic>);
       return ApiResponse<SearchResult>.completed(result);
+    }
+    return ApiResponse.error(response.bodyString);
+  }
+
+  @override
+  Future<ApiResponse<ProductSearchResponse>> searchProducts(
+    String query, {
+    String? pageToken,
+  }) async {
+    Response response;
+    try {
+      response = await _polaApiService.searchProducts(
+        query,
+        pageToken,
+        _deviceIdService.uuid,
+      );
+    } on SocketException catch (exception) {
+      return ApiResponse.error(exception.message);
+    }
+
+    if (response.isSuccessful) {
+      final result = ProductSearchResponse.fromJson(
+        response.body as Map<String, dynamic>,
+      );
+      return ApiResponse<ProductSearchResponse>.completed(result);
     }
     return ApiResponse.error(response.bodyString);
   }

--- a/lib/data/pola_api_service.dart
+++ b/lib/data/pola_api_service.dart
@@ -1,4 +1,4 @@
-﻿import 'package:chopper/chopper.dart';
+import 'package:chopper/chopper.dart';
 import 'package:pola_flutter/config/app_urls.dart';
 part 'pola_api_service.chopper.dart';
 
@@ -8,6 +8,13 @@ abstract class PolaApiService extends ChopperService {
   @GET(path: 'a/v4/get_by_code')
   Future<Response> getCompany(
     @Query("code") String code,
+    @Query("device_id") String deviceId,
+  );
+
+  @GET(path: 'a/v4/search')
+  Future<Response> searchProducts(
+    @Query("query") String query,
+    @Query("pageToken") String? pageToken,
     @Query("device_id") String deviceId,
   );
 

--- a/lib/data/product_search_history_service.dart
+++ b/lib/data/product_search_history_service.dart
@@ -1,0 +1,96 @@
+import 'dart:convert';
+
+import 'package:pola_flutter/models/product_search_response.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+abstract class ProductSearchHistoryStore {
+  Future<List<ProductSearchItem>> loadHistory();
+  Future<List<ProductSearchItem>> addProduct(ProductSearchItem product);
+  Future<List<ProductSearchItem>> clearHistory();
+  List<ProductSearchItem> filterHistory(
+    List<ProductSearchItem> history,
+    String query,
+  );
+}
+
+class ProductSearchHistoryService implements ProductSearchHistoryStore {
+  static const _historyKey = 'product_search_history';
+  static const _maxHistorySize = 50;
+
+  final SharedPreferences _prefs;
+
+  ProductSearchHistoryService(this._prefs);
+
+  static Future<ProductSearchHistoryService> create() async {
+    final prefs = await SharedPreferences.getInstance();
+    return ProductSearchHistoryService(prefs);
+  }
+
+  @override
+  Future<List<ProductSearchItem>> loadHistory() async {
+    final rawHistory = _prefs.getString(_historyKey);
+    if (rawHistory == null || rawHistory.isEmpty) {
+      return [];
+    }
+
+    try {
+      final decoded = jsonDecode(rawHistory) as List<dynamic>;
+      return decoded
+          .map(
+            (item) => ProductSearchItem.fromJson(item as Map<String, dynamic>),
+          )
+          .toList();
+    } on FormatException {
+      await clearHistory();
+      return [];
+    } on TypeError {
+      await clearHistory();
+      return [];
+    }
+  }
+
+  @override
+  Future<List<ProductSearchItem>> addProduct(ProductSearchItem product) async {
+    final existing = await loadHistory();
+    final updated = [
+      product,
+      ...existing.where((item) => item.code != product.code),
+    ].take(_maxHistorySize).toList();
+
+    await _save(updated);
+    return updated;
+  }
+
+  @override
+  Future<List<ProductSearchItem>> clearHistory() async {
+    await _prefs.remove(_historyKey);
+    return [];
+  }
+
+  @override
+  List<ProductSearchItem> filterHistory(
+    List<ProductSearchItem> history,
+    String query,
+  ) {
+    final normalizedQuery = query.trim().toLowerCase();
+    if (normalizedQuery.isEmpty) {
+      return history;
+    }
+
+    return history.where((product) {
+      return product.name.toLowerCase().contains(normalizedQuery) ||
+          product.code.toLowerCase().contains(normalizedQuery) ||
+          (product.company?.name.toLowerCase().contains(normalizedQuery) ??
+              false) ||
+          (product.brand?.name.toLowerCase().contains(normalizedQuery) ??
+              false);
+    }).toList();
+  }
+
+  Future<void> _save(List<ProductSearchItem> history) async {
+    final encoded = jsonEncode(
+      history.map((product) => product.toJson()).toList(),
+    );
+    await _prefs.setString(_historyKey, encoded);
+  }
+}

--- a/lib/i18n/en.i18n.json
+++ b/lib/i18n/en.i18n.json
@@ -38,7 +38,22 @@
         "search": "Wyszukaj"
     },
     "search": {
-        "title": "Wyszukiwarka"
+        "title": "Wyszukaj",
+        "historyTitle": "Historia",
+        "inputLabel": "Nazwa produktu / kod EAN",
+        "hint": "Wyszukaj",
+        "historyHint": "Wyszukaj produkt w historii",
+        "recentSearches": "Ostatnie wyszukiwania:",
+        "fullHistory": "Pełna historia:",
+        "clear": "Wyczyść",
+        "resultsCountOne": "Znaleziono 1 wynik:",
+        "resultsCountMany": "Znaleziono $count wyników:",
+        "noResults": "Brak wyników",
+        "emptyHistory": "Brak historii wyszukiwania",
+        "noHistoryResults": "Brak produktów pasujących do wyszukiwania",
+        "error": "Nie udało się pobrać wyników.",
+        "retry": "Spróbuj ponownie",
+        "openError": "Nie udało się otworzyć produktu."
     },
     "news": {
         "title": "Wiadomości"

--- a/lib/models/product_search_response.dart
+++ b/lib/models/product_search_response.dart
@@ -1,0 +1,95 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'product_search_response.g.dart';
+
+@JsonSerializable(explicitToJson: true)
+class ProductSearchResponse extends Equatable {
+  final String? nextPageToken;
+  final List<ProductSearchItem> products;
+  final int totalItems;
+
+  const ProductSearchResponse({
+    required this.nextPageToken,
+    required this.products,
+    required this.totalItems,
+  });
+
+  factory ProductSearchResponse.fromJson(Map<String, dynamic> json) =>
+      _$ProductSearchResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ProductSearchResponseToJson(this);
+
+  @override
+  List<Object?> get props => [nextPageToken, products, totalItems];
+}
+
+@JsonSerializable(explicitToJson: true)
+class ProductSearchItem extends Equatable {
+  final String name;
+  final String code;
+  final ProductSearchCompany? company;
+  final ProductSearchBrand? brand;
+
+  const ProductSearchItem({
+    required this.name,
+    required this.code,
+    this.company,
+    this.brand,
+  });
+
+  factory ProductSearchItem.fromJson(Map<String, dynamic> json) =>
+      _$ProductSearchItemFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ProductSearchItemToJson(this);
+
+  String get subtitle {
+    final companyName = company?.name;
+    if (companyName != null && companyName.isNotEmpty) {
+      return companyName;
+    }
+
+    final brandName = brand?.name;
+    if (brandName != null && brandName.isNotEmpty) {
+      return brandName;
+    }
+
+    return code;
+  }
+
+  int? get score => company?.score;
+
+  @override
+  List<Object?> get props => [name, code, company, brand];
+}
+
+@JsonSerializable()
+class ProductSearchCompany extends Equatable {
+  final String name;
+  final int? score;
+
+  const ProductSearchCompany({required this.name, required this.score});
+
+  factory ProductSearchCompany.fromJson(Map<String, dynamic> json) =>
+      _$ProductSearchCompanyFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ProductSearchCompanyToJson(this);
+
+  @override
+  List<Object?> get props => [name, score];
+}
+
+@JsonSerializable()
+class ProductSearchBrand extends Equatable {
+  final String name;
+
+  const ProductSearchBrand({required this.name});
+
+  factory ProductSearchBrand.fromJson(Map<String, dynamic> json) =>
+      _$ProductSearchBrandFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ProductSearchBrandToJson(this);
+
+  @override
+  List<Object?> get props => [name];
+}

--- a/lib/pages/scan/scan_navigator.dart
+++ b/lib/pages/scan/scan_navigator.dart
@@ -1,12 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:pola_flutter/i18n/strings.g.dart';
 import 'package:pola_flutter/models/search_result.dart';
 import 'package:pola_flutter/pages/detail/detail.dart';
 import 'package:pola_flutter/pages/dialpad/dialpad.dart';
 import 'package:pola_flutter/pages/report/report_page.dart';
 import 'package:pola_flutter/pages/scan/scan.dart';
-import 'package:pola_flutter/ui/web_view_tab.dart';
-import 'package:pola_flutter/config/app_urls.dart';
+import 'package:pola_flutter/pages/search/search_page.dart';
 
 class ScanNavigator extends StatefulWidget {
   final GlobalKey<NavigatorState>? navigatorKey;
@@ -94,12 +92,7 @@ class _ScanNavigatorState extends State<ScanNavigator> {
       case '/dialpad':
         return MaterialPageRoute(builder: (_) => DialPadPage());
       case '/search':
-        return MaterialPageRoute(
-          builder: (context) => WebViewTab(
-            title: Translations.of(context).search.title,
-            url: AppUrls.search,
-          ),
-        );
+        return MaterialPageRoute(builder: (_) => const SearchPage());
       case '/report':
         return MaterialPageRoute(
           builder: (_) => ReportPage(productId: args is int ? args : null),

--- a/lib/pages/search/search_bloc.dart
+++ b/lib/pages/search/search_bloc.dart
@@ -1,0 +1,334 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:pola_flutter/data/api_response.dart';
+import 'package:pola_flutter/data/pola_api_repository.dart';
+import 'package:pola_flutter/data/product_search_history_service.dart';
+import 'package:pola_flutter/models/product_search_response.dart';
+import 'package:pola_flutter/pages/search/search_event.dart';
+import 'package:pola_flutter/pages/search/search_state.dart';
+import 'package:rxdart/rxdart.dart';
+
+class SearchBloc extends Bloc<SearchEvent, SearchState> {
+  final PolaApi _repository;
+  final ProductSearchHistoryStore _historyStore;
+  final Duration _debounceDuration;
+  final Map<String, _CachedSearchResults> _resultsCache = {};
+  bool _paginationInFlight = false;
+
+  SearchBloc(
+    this._repository,
+    this._historyStore, {
+    Duration debounceDuration = const Duration(milliseconds: 500),
+  }) : _debounceDuration = debounceDuration,
+       super(const SearchState()) {
+    on<SearchStarted>(_onStarted);
+    on<SearchQueryChanged>(_onQueryChanged);
+    on<SearchRequested>(
+      _onSearchRequested,
+      transformer: _debounce(_debounceDuration),
+    );
+    on<SearchRetryRequested>(_onRetryRequested);
+    on<SearchNextPageRequested>(_onNextPageRequested);
+    on<SearchProductSelected>(_onProductSelected);
+    on<SearchResultOpened>(_onResultOpened);
+    on<SearchSelectionErrorShown>(_onSelectionErrorShown);
+    on<SearchHistoryCleared>(_onHistoryCleared);
+  }
+
+  List<ProductSearchItem> filterHistory(String query) {
+    return _historyStore.filterHistory(state.history, query);
+  }
+
+  Future<void> _onStarted(
+    SearchStarted event,
+    Emitter<SearchState> emit,
+  ) async {
+    final history = await _historyStore.loadHistory();
+    emit(state.copyWith(history: history));
+  }
+
+  void _onQueryChanged(SearchQueryChanged event, Emitter<SearchState> emit) {
+    final query = event.query;
+    final searchQuery = query.trim();
+    final cacheKey = _cacheKeyFor(query);
+    final previousCacheKey = _cacheKeyFor(state.query);
+
+    if (cacheKey == previousCacheKey) {
+      if (query != state.query) {
+        emit(state.copyWith(query: query));
+      }
+      return;
+    }
+
+    if (searchQuery.length < SearchState.minimumQueryLength) {
+      emit(
+        state.copyWith(
+          query: query,
+          results: [],
+          totalItems: 0,
+          nextPageToken: null,
+          requestState: SearchRequestState.idle,
+          searchErrorMessage: null,
+        ),
+      );
+      return;
+    }
+
+    final cachedResults = _resultsCache[cacheKey];
+    if (cachedResults != null) {
+      emit(
+        state.copyWith(
+          query: query,
+          results: cachedResults.results,
+          totalItems: cachedResults.totalItems,
+          nextPageToken: cachedResults.nextPageToken,
+          requestState: SearchRequestState.idle,
+          searchErrorMessage: null,
+        ),
+      );
+      return;
+    }
+
+    emit(
+      state.copyWith(
+        query: query,
+        results: [],
+        totalItems: 0,
+        nextPageToken: null,
+        requestState: SearchRequestState.typing,
+        searchErrorMessage: null,
+      ),
+    );
+
+    add(SearchEvent.requested(searchQuery));
+  }
+
+  Future<void> _onSearchRequested(
+    SearchRequested event,
+    Emitter<SearchState> emit,
+  ) async {
+    await _loadFirstPage(event.query, emit);
+  }
+
+  Future<void> _onRetryRequested(
+    SearchRetryRequested event,
+    Emitter<SearchState> emit,
+  ) async {
+    final query = state.query.trim();
+    if (query.length < SearchState.minimumQueryLength) {
+      return;
+    }
+
+    emit(
+      state.copyWith(
+        requestState: SearchRequestState.loading,
+        results: [],
+        totalItems: 0,
+        nextPageToken: null,
+        searchErrorMessage: null,
+      ),
+    );
+    await _loadFirstPage(query, emit, emitLoadingState: false);
+  }
+
+  Future<void> _onNextPageRequested(
+    SearchNextPageRequested event,
+    Emitter<SearchState> emit,
+  ) async {
+    if (_paginationInFlight || !state.canLoadMore) {
+      return;
+    }
+
+    final query = state.query.trim();
+    final cacheKey = _cacheKeyFor(query);
+    final pageToken = state.nextPageToken;
+    if (pageToken == null) {
+      return;
+    }
+
+    _paginationInFlight = true;
+    try {
+      emit(
+        state.copyWith(
+          requestState: SearchRequestState.loadingMore,
+          searchErrorMessage: null,
+        ),
+      );
+
+      final response = await _repository.searchProducts(
+        query,
+        pageToken: pageToken,
+      );
+      if (cacheKey != _cacheKeyFor(state.query)) {
+        return;
+      }
+
+      if (response.status == Status.completed) {
+        final data = response.data;
+        final results = _appendUniqueProducts(state.results, data.products);
+        _resultsCache[cacheKey] = _CachedSearchResults(
+          results: results,
+          totalItems: data.totalItems,
+          nextPageToken: data.nextPageToken,
+        );
+        emit(
+          state.copyWith(
+            results: results,
+            totalItems: data.totalItems,
+            nextPageToken: data.nextPageToken,
+            requestState: SearchRequestState.idle,
+            searchErrorMessage: null,
+          ),
+        );
+      } else {
+        emit(
+          state.copyWith(
+            requestState: SearchRequestState.error,
+            searchErrorMessage: response.message,
+          ),
+        );
+      }
+    } finally {
+      _paginationInFlight = false;
+    }
+  }
+
+  Future<void> _loadFirstPage(
+    String query,
+    Emitter<SearchState> emit, {
+    bool emitLoadingState = true,
+  }) async {
+    final cacheKey = _cacheKeyFor(query);
+    if (cacheKey != _cacheKeyFor(state.query)) {
+      return;
+    }
+    if (query.length < SearchState.minimumQueryLength) {
+      return;
+    }
+
+    if (emitLoadingState) {
+      emit(
+        state.copyWith(
+          requestState: SearchRequestState.loading,
+          searchErrorMessage: null,
+        ),
+      );
+    }
+
+    final response = await _repository.searchProducts(query);
+    if (cacheKey != _cacheKeyFor(state.query)) {
+      return;
+    }
+
+    if (response.status == Status.completed) {
+      final data = response.data;
+      _resultsCache[cacheKey] = _CachedSearchResults(
+        results: data.products,
+        totalItems: data.totalItems,
+        nextPageToken: data.nextPageToken,
+      );
+      emit(
+        state.copyWith(
+          results: data.products,
+          totalItems: data.totalItems,
+          nextPageToken: data.nextPageToken,
+          requestState: SearchRequestState.idle,
+          searchErrorMessage: null,
+        ),
+      );
+    } else {
+      emit(
+        state.copyWith(
+          requestState: SearchRequestState.error,
+          searchErrorMessage: response.message,
+        ),
+      );
+    }
+  }
+
+  Future<void> _onProductSelected(
+    SearchProductSelected event,
+    Emitter<SearchState> emit,
+  ) async {
+    if (state.isOpeningResult) {
+      return;
+    }
+
+    emit(
+      state.copyWith(
+        isOpeningResult: true,
+        openingProduct: event.product,
+        resultToOpen: null,
+        selectionErrorMessage: null,
+      ),
+    );
+
+    final response = await _repository.getCompany(event.product.code);
+    if (response.status == Status.completed) {
+      final history = await _historyStore.addProduct(event.product);
+      emit(
+        state.copyWith(
+          history: history,
+          isOpeningResult: false,
+          openingProduct: null,
+          resultToOpen: response.data,
+        ),
+      );
+    } else {
+      emit(
+        state.copyWith(
+          isOpeningResult: false,
+          openingProduct: null,
+          selectionErrorMessage: response.message,
+        ),
+      );
+    }
+  }
+
+  void _onResultOpened(SearchResultOpened event, Emitter<SearchState> emit) {
+    emit(state.copyWith(resultToOpen: null));
+  }
+
+  void _onSelectionErrorShown(
+    SearchSelectionErrorShown event,
+    Emitter<SearchState> emit,
+  ) {
+    emit(state.copyWith(selectionErrorMessage: null));
+  }
+
+  Future<void> _onHistoryCleared(
+    SearchHistoryCleared event,
+    Emitter<SearchState> emit,
+  ) async {
+    final history = await _historyStore.clearHistory();
+    emit(state.copyWith(history: history));
+  }
+
+  List<ProductSearchItem> _appendUniqueProducts(
+    List<ProductSearchItem> existing,
+    List<ProductSearchItem> nextPage,
+  ) {
+    final seenCodes = existing.map((product) => product.code).toSet();
+    final uniqueNextPage = nextPage.where((product) {
+      return seenCodes.add(product.code);
+    });
+    return [...existing, ...uniqueNextPage];
+  }
+
+  String _cacheKeyFor(String query) => query.trim().toLowerCase();
+}
+
+class _CachedSearchResults {
+  final List<ProductSearchItem> results;
+  final int totalItems;
+  final String? nextPageToken;
+
+  const _CachedSearchResults({
+    required this.results,
+    required this.totalItems,
+    required this.nextPageToken,
+  });
+}
+
+EventTransformer<Event> _debounce<Event>(Duration duration) {
+  return (events, mapper) => events.debounceTime(duration).switchMap(mapper);
+}

--- a/lib/pages/search/search_event.dart
+++ b/lib/pages/search/search_event.dart
@@ -1,0 +1,18 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:pola_flutter/models/product_search_response.dart';
+
+part 'search_event.freezed.dart';
+
+@freezed
+sealed class SearchEvent with _$SearchEvent {
+  const factory SearchEvent.started() = SearchStarted;
+  const factory SearchEvent.queryChanged(String query) = SearchQueryChanged;
+  const factory SearchEvent.retryRequested() = SearchRetryRequested;
+  const factory SearchEvent.nextPageRequested() = SearchNextPageRequested;
+  const factory SearchEvent.productSelected(ProductSearchItem product) =
+      SearchProductSelected;
+  const factory SearchEvent.resultOpened() = SearchResultOpened;
+  const factory SearchEvent.selectionErrorShown() = SearchSelectionErrorShown;
+  const factory SearchEvent.historyCleared() = SearchHistoryCleared;
+  const factory SearchEvent.requested(String query) = SearchRequested;
+}

--- a/lib/pages/search/search_history_page.dart
+++ b/lib/pages/search/search_history_page.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:pola_flutter/i18n/strings.g.dart';
+import 'package:pola_flutter/pages/search/search_bloc.dart';
+import 'package:pola_flutter/pages/search/search_event.dart';
+import 'package:pola_flutter/pages/search/search_state.dart';
+import 'package:pola_flutter/pages/search/widgets/recent_history_section.dart';
+import 'package:pola_flutter/pages/search/widgets/search_app_bar.dart';
+import 'package:pola_flutter/pages/search/widgets/search_floating_actions.dart';
+import 'package:pola_flutter/pages/search/widgets/search_input.dart';
+import 'package:pola_flutter/theme/colors.dart';
+
+class SearchHistoryPage extends StatefulWidget {
+  const SearchHistoryPage({super.key});
+
+  @override
+  State<SearchHistoryPage> createState() => _SearchHistoryPageState();
+}
+
+class _SearchHistoryPageState extends State<SearchHistoryPage> {
+  final _filterController = TextEditingController();
+  String _filter = '';
+
+  @override
+  void dispose() {
+    _filterController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<SearchBloc, SearchState>(
+      listenWhen: (previous, current) =>
+          previous.resultToOpen != current.resultToOpen ||
+          previous.selectionErrorMessage != current.selectionErrorMessage,
+      listener: _onStateChanged,
+      child: Scaffold(
+        backgroundColor: AppColors.white,
+        appBar: SearchAppBar(title: t.search.historyTitle),
+        floatingActionButton: HistoryFloatingActions(
+          onScannerTap: () =>
+              Navigator.of(context).popUntil((route) => route.isFirst),
+        ),
+        body: SafeArea(
+          child: BlocBuilder<SearchBloc, SearchState>(
+            builder: (context, state) {
+              final filteredHistory = context.read<SearchBloc>().filterHistory(
+                _filter,
+              );
+
+              return CustomScrollView(
+                slivers: [
+                  SliverPadding(
+                    padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+                    sliver: SliverToBoxAdapter(
+                      child: SearchInput(
+                        controller: _filterController,
+                        query: _filter,
+                        hintText: t.search.historyHint,
+                        onChanged: (value) {
+                          setState(() {
+                            _filter = value;
+                          });
+                        },
+                        onClear: () {
+                          _filterController.clear();
+                          setState(() {
+                            _filter = '';
+                          });
+                        },
+                      ),
+                    ),
+                  ),
+                  const SliverToBoxAdapter(child: SizedBox(height: 24)),
+                  if (state.history.isEmpty)
+                    const SliverPadding(
+                      padding: EdgeInsets.symmetric(horizontal: 16),
+                      sliver: SliverToBoxAdapter(child: EmptyHistory()),
+                    )
+                  else if (_filter.trim().isNotEmpty)
+                    FullHistorySection(products: filteredHistory)
+                  else ...[
+                    SearchHistoryPreview(products: state.history.take(3)),
+                    const SliverToBoxAdapter(child: SizedBox(height: 16)),
+                    const SliverPadding(
+                      padding: EdgeInsets.symmetric(horizontal: 16),
+                      sliver: SliverToBoxAdapter(
+                        child: Divider(color: AppColors.divider),
+                      ),
+                    ),
+                    const SliverToBoxAdapter(child: SizedBox(height: 16)),
+                    FullHistorySection(products: state.history),
+                  ],
+                  const SliverToBoxAdapter(child: SizedBox(height: 96)),
+                ],
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _onStateChanged(BuildContext context, SearchState state) {
+    final resultToOpen = state.resultToOpen;
+    if (resultToOpen != null) {
+      context.read<SearchBloc>().add(const SearchEvent.resultOpened());
+      Navigator.of(context).pushNamed('/detail', arguments: resultToOpen);
+      return;
+    }
+
+    final selectionErrorMessage = state.selectionErrorMessage;
+    if (selectionErrorMessage != null) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(t.search.openError)));
+      context.read<SearchBloc>().add(const SearchEvent.selectionErrorShown());
+    }
+  }
+}

--- a/lib/pages/search/search_page.dart
+++ b/lib/pages/search/search_page.dart
@@ -1,0 +1,182 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:pola_flutter/data/pola_api_repository.dart';
+import 'package:pola_flutter/data/product_search_history_service.dart';
+import 'package:pola_flutter/i18n/strings.g.dart';
+import 'package:pola_flutter/pages/search/search_bloc.dart';
+import 'package:pola_flutter/pages/search/search_event.dart';
+import 'package:pola_flutter/pages/search/search_history_page.dart';
+import 'package:pola_flutter/pages/search/search_state.dart';
+import 'package:pola_flutter/pages/search/widgets/recent_history_section.dart';
+import 'package:pola_flutter/pages/search/widgets/search_app_bar.dart';
+import 'package:pola_flutter/pages/search/widgets/search_floating_actions.dart';
+import 'package:pola_flutter/pages/search/widgets/search_input.dart';
+import 'package:pola_flutter/pages/search/widgets/search_results_section.dart';
+import 'package:pola_flutter/theme/colors.dart';
+
+class SearchPage extends StatefulWidget {
+  const SearchPage({super.key});
+
+  @override
+  State<SearchPage> createState() => _SearchPageState();
+}
+
+class _SearchPageState extends State<SearchPage> {
+  late final Future<SearchBloc> _blocFuture;
+  SearchBloc? _bloc;
+
+  @override
+  void initState() {
+    super.initState();
+    final repository = context.read<PolaApi>();
+    _blocFuture = ProductSearchHistoryService.create().then((historyStore) {
+      final bloc = SearchBloc(repository, historyStore)
+        ..add(const SearchEvent.started());
+      _bloc = bloc;
+      return bloc;
+    });
+  }
+
+  @override
+  void dispose() {
+    _bloc?.close();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<SearchBloc>(
+      future: _blocFuture,
+      builder: (context, snapshot) {
+        final bloc = snapshot.data;
+        if (bloc == null) {
+          return const Scaffold(
+            backgroundColor: AppColors.white,
+            body: Center(child: CircularProgressIndicator()),
+          );
+        }
+
+        return BlocProvider.value(value: bloc, child: const _SearchView());
+      },
+    );
+  }
+}
+
+class _SearchView extends StatefulWidget {
+  const _SearchView();
+
+  @override
+  State<_SearchView> createState() => _SearchViewState();
+}
+
+class _SearchViewState extends State<_SearchView> {
+  final _queryController = TextEditingController();
+  final _scrollController = ScrollController();
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController.addListener(_onScroll);
+  }
+
+  @override
+  void dispose() {
+    _queryController.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (!_scrollController.hasClients) {
+      return;
+    }
+
+    final position = _scrollController.position;
+    if (position.pixels >= position.maxScrollExtent - 240) {
+      context.read<SearchBloc>().add(const SearchEvent.nextPageRequested());
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<SearchBloc, SearchState>(
+      listenWhen: (previous, current) =>
+          previous.resultToOpen != current.resultToOpen ||
+          previous.selectionErrorMessage != current.selectionErrorMessage,
+      listener: _onStateChanged,
+      child: Scaffold(
+        backgroundColor: AppColors.white,
+        appBar: SearchAppBar(title: t.search.title),
+        floatingActionButton: SearchFloatingActions(
+          onHistoryTap: _openHistory,
+          onScannerTap: () => Navigator.of(context).pop(),
+        ),
+        body: SafeArea(
+          child: BlocBuilder<SearchBloc, SearchState>(
+            builder: (context, state) {
+              return CustomScrollView(
+                controller: _scrollController,
+                slivers: [
+                  SliverPadding(
+                    padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+                    sliver: SliverToBoxAdapter(
+                      child: SearchInput(
+                        controller: _queryController,
+                        query: state.query,
+                        hintText: t.search.hint,
+                        showSearchIcon: state.query.isEmpty,
+                        onChanged: (query) {
+                          context.read<SearchBloc>().add(
+                            SearchEvent.queryChanged(query),
+                          );
+                        },
+                        onClear: () {
+                          _queryController.clear();
+                          context.read<SearchBloc>().add(
+                            const SearchEvent.queryChanged(''),
+                          );
+                        },
+                      ),
+                    ),
+                  ),
+                  const SliverToBoxAdapter(child: SizedBox(height: 24)),
+                  if (state.hasSearchableQuery)
+                    SearchResultsSection(state: state),
+                  RecentHistorySection(state: state),
+                  const SliverToBoxAdapter(child: SizedBox(height: 96)),
+                ],
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _onStateChanged(BuildContext context, SearchState state) {
+    final resultToOpen = state.resultToOpen;
+    if (resultToOpen != null) {
+      context.read<SearchBloc>().add(const SearchEvent.resultOpened());
+      Navigator.of(context).pushNamed('/detail', arguments: resultToOpen);
+      return;
+    }
+
+    final selectionErrorMessage = state.selectionErrorMessage;
+    if (selectionErrorMessage != null) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(t.search.openError)));
+      context.read<SearchBloc>().add(const SearchEvent.selectionErrorShown());
+    }
+  }
+
+  void _openHistory() {
+    final bloc = context.read<SearchBloc>();
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) =>
+            BlocProvider.value(value: bloc, child: const SearchHistoryPage()),
+      ),
+    );
+  }
+}

--- a/lib/pages/search/search_state.dart
+++ b/lib/pages/search/search_state.dart
@@ -1,0 +1,38 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:pola_flutter/models/product_search_response.dart';
+import 'package:pola_flutter/models/search_result.dart';
+
+part 'search_state.freezed.dart';
+
+enum SearchRequestState { idle, typing, loading, loadingMore, error }
+
+@freezed
+abstract class SearchState with _$SearchState {
+  static const minimumQueryLength = 2;
+
+  const SearchState._();
+
+  const factory SearchState({
+    @Default('') String query,
+    @Default([]) List<ProductSearchItem> results,
+    @Default(0) int totalItems,
+    String? nextPageToken,
+    @Default([]) List<ProductSearchItem> history,
+    @Default(SearchRequestState.idle) SearchRequestState requestState,
+    @Default(false) bool isOpeningResult,
+    ProductSearchItem? openingProduct,
+    SearchResult? resultToOpen,
+    String? searchErrorMessage,
+    String? selectionErrorMessage,
+  }) = _SearchState;
+
+  bool get hasQuery => query.trim().isNotEmpty;
+  bool get hasSearchableQuery => query.trim().length >= minimumQueryLength;
+  bool get hasResults => results.isNotEmpty;
+  bool get canLoadMore =>
+      hasSearchableQuery &&
+      nextPageToken != null &&
+      requestState != SearchRequestState.typing &&
+      requestState != SearchRequestState.loading &&
+      requestState != SearchRequestState.loadingMore;
+}

--- a/lib/pages/search/widgets/product_search_tile.dart
+++ b/lib/pages/search/widgets/product_search_tile.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:pola_flutter/models/product_search_response.dart';
+import 'package:pola_flutter/pages/search/search_bloc.dart';
+import 'package:pola_flutter/pages/search/search_event.dart';
+import 'package:pola_flutter/pages/search/search_state.dart';
+import 'package:pola_flutter/theme/colors.dart';
+import 'package:pola_flutter/ui/product_list_item.dart';
+
+class ProductSearchTile extends StatelessWidget {
+  final ProductSearchItem product;
+
+  const ProductSearchTile({super.key, required this.product});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocSelector<SearchBloc, SearchState, bool>(
+      selector: (state) =>
+          state.isOpeningResult && state.openingProduct?.code == product.code,
+      builder: (context, isOpening) {
+        return ProductListItem(
+          score: product.score,
+          title: product.name,
+          subtitle: product.subtitle,
+          minHeight: 64,
+          scoreWidth: 52,
+          margin: const EdgeInsets.symmetric(vertical: 4),
+          contentPadding: const EdgeInsets.symmetric(vertical: 8),
+          border: Border.all(color: AppColors.divider),
+          titleMaxLines: 2,
+          onTap: isOpening
+              ? null
+              : () {
+                  context.read<SearchBloc>().add(
+                    SearchEvent.productSelected(product),
+                  );
+                },
+          trailing: isOpening
+              ? const SizedBox(child: CircularProgressIndicator())
+              : const Icon(Icons.chevron_right, color: AppColors.text),
+        );
+      },
+    );
+  }
+}

--- a/lib/pages/search/widgets/recent_history_section.dart
+++ b/lib/pages/search/widgets/recent_history_section.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:pola_flutter/i18n/strings.g.dart';
+import 'package:pola_flutter/models/product_search_response.dart';
+import 'package:pola_flutter/pages/search/search_bloc.dart';
+import 'package:pola_flutter/pages/search/search_event.dart';
+import 'package:pola_flutter/pages/search/search_state.dart';
+import 'package:pola_flutter/pages/search/widgets/product_search_tile.dart';
+import 'package:pola_flutter/pages/search/widgets/section_header.dart';
+import 'package:pola_flutter/theme/colors.dart';
+import 'package:pola_flutter/theme/text_size.dart';
+
+class RecentHistorySection extends StatelessWidget {
+  final SearchState state;
+
+  const RecentHistorySection({super.key, required this.state});
+
+  @override
+  Widget build(BuildContext context) {
+    final recentProducts = state.history.take(3).toList();
+    if (recentProducts.isEmpty) {
+      return const SliverToBoxAdapter(child: SizedBox.shrink());
+    }
+
+    return SearchHistoryPreview(products: recentProducts);
+  }
+}
+
+class SearchHistoryPreview extends StatelessWidget {
+  final Iterable<ProductSearchItem> products;
+
+  const SearchHistoryPreview({super.key, required this.products});
+
+  @override
+  Widget build(BuildContext context) {
+    final productsList = products.toList();
+
+    return SliverMainAxisGroup(
+      slivers: [
+        SliverPadding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          sliver: SliverToBoxAdapter(
+            child: SectionHeader(
+              title: t.search.recentSearches,
+              actionText: t.search.clear,
+              onActionTap: () {
+                context.read<SearchBloc>().add(
+                  const SearchEvent.historyCleared(),
+                );
+              },
+            ),
+          ),
+        ),
+        const SliverToBoxAdapter(child: SizedBox(height: 8)),
+        SliverPadding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          sliver: SliverList.builder(
+            itemCount: productsList.length,
+            itemBuilder: (context, index) {
+              return ProductSearchTile(product: productsList[index]);
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class FullHistorySection extends StatelessWidget {
+  final Iterable<ProductSearchItem> products;
+
+  const FullHistorySection({super.key, required this.products});
+
+  @override
+  Widget build(BuildContext context) {
+    final productsList = products.toList();
+
+    return SliverMainAxisGroup(
+      slivers: [
+        SliverPadding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          sliver: SliverToBoxAdapter(
+            child: SearchSectionTitle(title: t.search.fullHistory),
+          ),
+        ),
+        const SliverToBoxAdapter(child: SizedBox(height: 8)),
+        if (productsList.isEmpty)
+          SliverPadding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            sliver: SliverToBoxAdapter(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 16),
+                child: Text(t.search.noHistoryResults),
+              ),
+            ),
+          )
+        else
+          SliverPadding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            sliver: SliverList.builder(
+              itemCount: productsList.length,
+              itemBuilder: (context, index) {
+                return ProductSearchTile(product: productsList[index]);
+              },
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class EmptyHistory extends StatelessWidget {
+  const EmptyHistory({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 24),
+      child: Text(
+        t.search.emptyHistory,
+        style: const TextStyle(
+          color: AppColors.text,
+          fontSize: TextSize.mediumTitle,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/search/widgets/search_app_bar.dart
+++ b/lib/pages/search/widgets/search_app_bar.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:pola_flutter/theme/colors.dart';
+import 'package:pola_flutter/theme/fonts.gen.dart';
+import 'package:pola_flutter/theme/text_size.dart';
+import 'package:pola_flutter/ui/menu_icon_button.dart';
+
+class SearchAppBar extends StatelessWidget implements PreferredSizeWidget {
+  final String title;
+
+  const SearchAppBar({super.key, required this.title});
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      backgroundColor: AppColors.white,
+      elevation: 0,
+      leading: BackButton(color: AppColors.text),
+      titleSpacing: 0,
+      title: Text(
+        title,
+        style: const TextStyle(
+          color: AppColors.text,
+          fontSize: TextSize.pageTitle,
+          fontFamily: FontFamily.lato,
+          fontWeight: FontWeight.w700,
+        ),
+      ),
+      actions: [MenuIconButton(color: AppColors.text)],
+    );
+  }
+}

--- a/lib/pages/search/widgets/search_error.dart
+++ b/lib/pages/search/widgets/search_error.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:pola_flutter/i18n/strings.g.dart';
+import 'package:pola_flutter/theme/colors.dart';
+
+class SearchError extends StatelessWidget {
+  final bool compact;
+  final VoidCallback onRetry;
+
+  const SearchError({super.key, required this.onRetry, this.compact = false});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.symmetric(vertical: compact ? 8 : 24),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              t.search.error,
+              style: const TextStyle(color: AppColors.text),
+            ),
+          ),
+          TextButton(onPressed: onRetry, child: Text(t.search.retry)),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/search/widgets/search_floating_actions.dart
+++ b/lib/pages/search/widgets/search_floating_actions.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:pola_flutter/theme/colors.dart';
+
+class SearchFloatingActions extends StatelessWidget {
+  final VoidCallback onHistoryTap;
+  final VoidCallback onScannerTap;
+
+  const SearchFloatingActions({
+    super.key,
+    required this.onHistoryTap,
+    required this.onScannerTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        FloatingActionButton.small(
+          heroTag: 'search-history',
+          backgroundColor: AppColors.buttonBackground,
+          foregroundColor: AppColors.defaultRed,
+          onPressed: onHistoryTap,
+          child: const Icon(Icons.history),
+        ),
+        const SizedBox(height: 8),
+        FloatingActionButton.small(
+          heroTag: 'search-scanner',
+          backgroundColor: AppColors.buttonBackground,
+          foregroundColor: AppColors.defaultRed,
+          onPressed: onScannerTap,
+          child: const Icon(Icons.qr_code_scanner),
+        ),
+      ],
+    );
+  }
+}
+
+class HistoryFloatingActions extends StatelessWidget {
+  final VoidCallback onScannerTap;
+
+  const HistoryFloatingActions({super.key, required this.onScannerTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        FloatingActionButton.small(
+          heroTag: 'history-scanner',
+          backgroundColor: AppColors.buttonBackground,
+          foregroundColor: AppColors.defaultRed,
+          onPressed: onScannerTap,
+          child: const Icon(Icons.qr_code_scanner),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/pages/search/widgets/search_input.dart
+++ b/lib/pages/search/widgets/search_input.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:pola_flutter/i18n/strings.g.dart';
+import 'package:pola_flutter/theme/assets.gen.dart';
+import 'package:pola_flutter/theme/colors.dart';
+import 'package:pola_flutter/theme/fonts.gen.dart';
+import 'package:pola_flutter/theme/text_size.dart';
+
+class SearchInput extends StatelessWidget {
+  final TextEditingController controller;
+  final String query;
+  final String hintText;
+  final bool showSearchIcon;
+  final ValueChanged<String> onChanged;
+  final VoidCallback onClear;
+
+  const SearchInput({
+    super.key,
+    required this.controller,
+    required this.query,
+    required this.hintText,
+    required this.onChanged,
+    required this.onClear,
+    this.showSearchIcon = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            const Icon(Icons.info_outline, size: 14, color: AppColors.text),
+            const SizedBox(width: 4),
+            Text(
+              t.search.inputLabel,
+              style: const TextStyle(
+                color: AppColors.text,
+                fontSize: TextSize.description,
+                fontFamily: FontFamily.lato,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        TextField(
+          controller: controller,
+          onChanged: onChanged,
+          textInputAction: TextInputAction.search,
+          decoration: InputDecoration(
+            hintText: hintText,
+            hintStyle: const TextStyle(color: AppColors.inactive),
+            filled: true,
+            fillColor: AppColors.textField,
+            prefixIcon: showSearchIcon
+                ? Padding(
+                    padding: const EdgeInsets.all(14),
+                    child: Assets.search.svg(
+                      colorFilter: const ColorFilter.mode(
+                        AppColors.inactive,
+                        BlendMode.srcIn,
+                      ),
+                    ),
+                  )
+                : null,
+            suffixIcon: query.isNotEmpty
+                ? IconButton(
+                    onPressed: onClear,
+                    icon: const Icon(Icons.close, color: AppColors.text),
+                  )
+                : null,
+            contentPadding: const EdgeInsets.symmetric(
+              horizontal: 18,
+              vertical: 14,
+            ),
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(28),
+              borderSide: BorderSide.none,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/pages/search/widgets/search_results_section.dart
+++ b/lib/pages/search/widgets/search_results_section.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:pola_flutter/i18n/strings.g.dart';
+import 'package:pola_flutter/pages/search/search_bloc.dart';
+import 'package:pola_flutter/pages/search/search_event.dart';
+import 'package:pola_flutter/pages/search/search_state.dart';
+import 'package:pola_flutter/pages/search/widgets/product_search_tile.dart';
+import 'package:pola_flutter/pages/search/widgets/search_error.dart';
+import 'package:pola_flutter/pages/search/widgets/section_header.dart';
+import 'package:pola_flutter/theme/colors.dart';
+
+class SearchResultsSection extends StatelessWidget {
+  final SearchState state;
+
+  const SearchResultsSection({super.key, required this.state});
+
+  @override
+  Widget build(BuildContext context) {
+    if (state.requestState == SearchRequestState.typing && !state.hasResults) {
+      return const SliverToBoxAdapter(child: SizedBox.shrink());
+    }
+
+    if (state.requestState == SearchRequestState.loading && !state.hasResults) {
+      return const SliverPadding(
+        padding: EdgeInsets.symmetric(horizontal: 16),
+        sliver: SliverToBoxAdapter(
+          child: Padding(
+            padding: EdgeInsets.symmetric(vertical: 24),
+            child: Center(child: CircularProgressIndicator()),
+          ),
+        ),
+      );
+    }
+
+    if (state.requestState == SearchRequestState.error && !state.hasResults) {
+      return SliverPadding(
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        sliver: SliverToBoxAdapter(
+          child: SearchError(
+            onRetry: () {
+              context.read<SearchBloc>().add(
+                const SearchEvent.retryRequested(),
+              );
+            },
+          ),
+        ),
+      );
+    }
+
+    if (!state.hasResults) {
+      return SliverPadding(
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        sliver: SliverToBoxAdapter(
+          child: Padding(
+            padding: const EdgeInsets.only(bottom: 24),
+            child: SearchSectionTitle(title: t.search.noResults),
+          ),
+        ),
+      );
+    }
+
+    return SliverMainAxisGroup(
+      slivers: [
+        SliverPadding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          sliver: SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.only(bottom: 10),
+              child: SearchSectionTitle(
+                title: _resultsCountText(state.totalItems),
+              ),
+            ),
+          ),
+        ),
+        SliverPadding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          sliver: SliverList.builder(
+            itemCount: state.results.length,
+            itemBuilder: (context, index) {
+              return ProductSearchTile(product: state.results[index]);
+            },
+          ),
+        ),
+        if (state.requestState == SearchRequestState.loadingMore)
+          const SliverPadding(
+            padding: EdgeInsets.symmetric(horizontal: 16),
+            sliver: SliverToBoxAdapter(
+              child: Padding(
+                padding: EdgeInsets.symmetric(vertical: 16),
+                child: Center(child: CircularProgressIndicator()),
+              ),
+            ),
+          ),
+        if (state.requestState == SearchRequestState.error)
+          SliverPadding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            sliver: SliverToBoxAdapter(
+              child: SearchError(
+                compact: true,
+                onRetry: () {
+                  context.read<SearchBloc>().add(
+                    const SearchEvent.nextPageRequested(),
+                  );
+                },
+              ),
+            ),
+          ),
+        const SliverPadding(
+          padding: EdgeInsets.fromLTRB(16, 8, 16, 20),
+          sliver: SliverToBoxAdapter(child: Divider(color: AppColors.divider)),
+        ),
+      ],
+    );
+  }
+
+  String _resultsCountText(int count) {
+    if (count == 1) {
+      return t.search.resultsCountOne;
+    }
+    return t.search.resultsCountMany(count: count);
+  }
+}

--- a/lib/pages/search/widgets/section_header.dart
+++ b/lib/pages/search/widgets/section_header.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:pola_flutter/theme/colors.dart';
+import 'package:pola_flutter/theme/text_size.dart';
+
+class SearchSectionTitle extends StatelessWidget {
+  final String title;
+
+  const SearchSectionTitle({super.key, required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      title,
+      style: const TextStyle(
+        fontSize: TextSize.mediumTitle,
+        fontWeight: FontWeight.w700,
+        color: AppColors.text,
+      ),
+    );
+  }
+}
+
+class SectionHeader extends StatelessWidget {
+  final String title;
+  final String? actionText;
+  final VoidCallback? onActionTap;
+
+  const SectionHeader({
+    super.key,
+    required this.title,
+    this.actionText,
+    this.onActionTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Expanded(child: SearchSectionTitle(title: title)),
+        if (actionText != null)
+          TextButton(
+            onPressed: onActionTap,
+            child: Text(
+              actionText!,
+              style: const TextStyle(
+                color: AppColors.defaultRed,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/ui/list_item.dart
+++ b/lib/ui/list_item.dart
@@ -1,83 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:pola_flutter/i18n/strings.g.dart';
 import 'package:pola_flutter/models/search_result.dart';
-import 'package:pola_flutter/theme/assets.gen.dart';
-import 'package:pola_flutter/theme/colors.dart';
-import 'package:pola_flutter/theme/fonts.gen.dart';
+import 'package:pola_flutter/ui/product_list_item.dart';
 import 'package:pola_flutter/theme/text_size.dart';
 
 class ResultListItem extends StatelessWidget {
   const ResultListItem({super.key, required this.searchResult});
 
   final SearchResult searchResult;
-  static const double leftBoxSize = 40.0;
 
   @override
   Widget build(BuildContext context) {
-    final pointValueStyle = TextStyle(
-      height: 0,
-      fontWeight: FontWeight.w700,
-      fontFamily: FontFamily.roboto,
-      fontSize: TextSize.mediumTitle,
-      color: Colors.white,
-    );
-
-    final pointDescriptionStyle = TextStyle(
-      height: 0.1,
-      fontWeight: FontWeight.w700,
-      fontFamily: FontFamily.roboto,
-      fontSize: 9,
-      color: Colors.white,
-    );
-
-    return _ListItem(
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          Container(
-            width: leftBoxSize,
-            height: leftBoxSize,
-            decoration: BoxDecoration(
-              color: AppColors.defaultRed,
-              borderRadius: BorderRadius.only(
-                topLeft: Radius.circular(leftBoxSize / 2),
-                bottomLeft: Radius.circular(leftBoxSize / 2),
-              ),
-            ),
-            alignment: Alignment.center,
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Text(
-                  '${searchResult.companies?.first.plScore ?? 0}',
-                  style: pointValueStyle,
-                  textAlign: TextAlign.center,
-                ),
-                Text(
-                  t.scan.pkt,
-                  style: pointDescriptionStyle,
-                  textAlign: TextAlign.center,
-                ),
-              ],
-            ),
-          ),
-          SizedBox(width: 8.0),
-          Expanded(
-            child: Container(
-              alignment: Alignment.centerLeft,
-              child: Text(
-                searchResult.name!,
-                style: TextStyle(
-                  fontWeight: FontWeight.w400,
-                  fontSize: TextSize.smallTitle,
-                ),
-                overflow: TextOverflow.ellipsis,
-                maxLines: 1,
-              ),
-            ),
-          ),
-        ],
-      ),
+    return ProductListItem(
+      score: searchResult.companies?.first.plScore ?? 0,
+      title: searchResult.name ?? '',
     );
   }
 }
@@ -88,7 +24,6 @@ class LoadingListItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return _ListItem(
-      showMore: false,
       child: Align(
         alignment: Alignment.centerLeft,
         child: Padding(
@@ -116,9 +51,8 @@ class LoadingListItem extends StatelessWidget {
 
 class _ListItem extends StatelessWidget {
   final Widget child;
-  final bool showMore;
 
-  const _ListItem({required this.child, this.showMore = true});
+  const _ListItem({required this.child});
 
   @override
   Widget build(BuildContext context) {
@@ -138,14 +72,7 @@ class _ListItem extends StatelessWidget {
           ),
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Expanded(child: child),
-              if (showMore)
-                Padding(
-                  padding: EdgeInsets.only(right: 8.0),
-                  child: Assets.scan.showMore.svg(),
-                ),
-            ],
+            children: [Expanded(child: child)],
           ),
         ),
       ),

--- a/lib/ui/product_list_item.dart
+++ b/lib/ui/product_list_item.dart
@@ -1,0 +1,169 @@
+import 'package:flutter/material.dart';
+import 'package:pola_flutter/theme/assets.gen.dart';
+import 'package:pola_flutter/theme/colors.dart';
+import 'package:pola_flutter/theme/fonts.gen.dart';
+import 'package:pola_flutter/theme/text_size.dart';
+import 'package:pola_flutter/ui/score_badge.dart';
+
+class ProductListItem extends StatelessWidget {
+  final int? score;
+  final String title;
+  final String? subtitle;
+  final VoidCallback? onTap;
+  final Widget? trailing;
+  final double minHeight;
+  final double scoreWidth;
+  final EdgeInsetsGeometry margin;
+  final EdgeInsetsGeometry contentPadding;
+  final int titleMaxLines;
+  final BoxBorder? border;
+
+  const ProductListItem({
+    super.key,
+    required this.score,
+    required this.title,
+    this.subtitle,
+    this.onTap,
+    this.trailing,
+    this.minHeight = 40,
+    this.scoreWidth = 40,
+    this.margin = const EdgeInsets.only(top: 4, left: 16, right: 8, bottom: 4),
+    this.contentPadding = const EdgeInsets.symmetric(vertical: 4),
+    this.titleMaxLines = 1,
+    this.border,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final borderRadius = BorderRadius.circular(minHeight / 2);
+
+    return Padding(
+      padding: margin,
+      child: Material(
+        color: AppColors.white,
+        borderRadius: borderRadius,
+        child: InkWell(
+          borderRadius: borderRadius,
+          onTap: onTap,
+          child: ConstrainedBox(
+            constraints: BoxConstraints(minHeight: minHeight),
+            child: Container(
+              foregroundDecoration: BoxDecoration(
+                borderRadius: borderRadius,
+                border: border,
+              ),
+              child: IntrinsicHeight(
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    ScoreBadge(
+                      score: score,
+                      width: scoreWidth,
+                      minHeight: minHeight,
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Padding(
+                        padding: contentPadding,
+                        child: _ProductListText(
+                          title: title,
+                          subtitle: subtitle,
+                          titleMaxLines: titleMaxLines,
+                        ),
+                      ),
+                    ),
+                    _ProductListTrailing(trailing: trailing),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ProductListText extends StatelessWidget {
+  final String title;
+  final String? subtitle;
+  final int titleMaxLines;
+
+  const _ProductListText({
+    required this.title,
+    this.subtitle,
+    required this.titleMaxLines,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final subtitle = this.subtitle;
+
+    if (subtitle == null || subtitle.isEmpty) {
+      return Align(
+        alignment: Alignment.centerLeft,
+        child: Text(
+          title,
+          style: const TextStyle(
+            fontWeight: FontWeight.w400,
+            fontSize: TextSize.smallTitle,
+          ),
+          overflow: TextOverflow.ellipsis,
+          maxLines: titleMaxLines,
+        ),
+      );
+    }
+
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          maxLines: titleMaxLines,
+          overflow: TextOverflow.ellipsis,
+          style: const TextStyle(
+            color: AppColors.text,
+            fontSize: TextSize.smallTitle,
+            fontWeight: FontWeight.w700,
+            fontFamily: FontFamily.lato,
+          ),
+        ),
+        const SizedBox(height: 3),
+        Text(
+          subtitle,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: const TextStyle(
+            color: AppColors.text,
+            fontSize: TextSize.description,
+            fontFamily: FontFamily.lato,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ProductListTrailing extends StatelessWidget {
+  final Widget? trailing;
+
+  const _ProductListTrailing({required this.trailing});
+
+  @override
+  Widget build(BuildContext context) {
+    final trailing = this.trailing;
+
+    if (trailing != null) {
+      return Padding(
+        padding: const EdgeInsets.only(left: 8, right: 14),
+        child: Center(child: trailing),
+      );
+    }
+
+    return Padding(
+      padding: const EdgeInsets.only(right: 8),
+      child: Assets.scan.showMore.svg(),
+    );
+  }
+}

--- a/lib/ui/score_badge.dart
+++ b/lib/ui/score_badge.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:pola_flutter/i18n/strings.g.dart';
+import 'package:pola_flutter/theme/colors.dart';
+import 'package:pola_flutter/theme/fonts.gen.dart';
+import 'package:pola_flutter/theme/text_size.dart';
+
+class ScoreBadge extends StatelessWidget {
+  final int? score;
+  final double width;
+  final double minHeight;
+
+  const ScoreBadge({
+    super.key,
+    required this.score,
+    required this.width,
+    required this.minHeight,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final compact = minHeight <= 44;
+
+    return SizedBox(
+      width: width,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(minHeight: minHeight),
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: AppColors.defaultRed,
+            borderRadius: BorderRadius.only(
+              topLeft: Radius.circular(minHeight / 2),
+              bottomLeft: Radius.circular(minHeight / 2),
+            ),
+          ),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(
+                score?.toString() ?? '-',
+                style: TextStyle(
+                  height: compact ? 0 : 1,
+                  fontWeight: FontWeight.w700,
+                  fontFamily: FontFamily.roboto,
+                  fontSize: compact ? TextSize.mediumTitle : TextSize.newsTitle,
+                  color: AppColors.white,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              Text(
+                t.scan.pkt,
+                style: TextStyle(
+                  height: compact ? 0.1 : 1.1,
+                  fontWeight: FontWeight.w700,
+                  fontFamily: FontFamily.roboto,
+                  fontSize: compact ? 9 : 10,
+                  color: AppColors.white,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1356,4 +1356,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.10.0 <4.0.0"
-  flutter: ">=3.35.1"
+  flutter: ">=3.38.0"

--- a/test/replacement_bloc_test.dart
+++ b/test/replacement_bloc_test.dart
@@ -5,6 +5,7 @@ import 'package:pola_flutter/analytics/pola_analytics.dart';
 import 'package:pola_flutter/data/api_response.dart';
 import 'package:pola_flutter/data/pola_api_repository.dart';
 import 'package:pola_flutter/models/donate.dart';
+import 'package:pola_flutter/models/product_search_response.dart';
 import 'package:pola_flutter/models/replacement.dart';
 import 'package:pola_flutter/models/search_result.dart';
 import 'package:pola_flutter/pages/detail/replacement/replacement_bloc.dart';
@@ -209,5 +210,12 @@ class _MockPolaApi extends PolaApi {
   @override
   Future<bool> createReport({required String description, int? productId}) =>
       Future.value(true);
-}
 
+  @override
+  Future<ApiResponse<ProductSearchResponse>> searchProducts(
+    String query, {
+    String? pageToken,
+  }) {
+    throw UnimplementedError();
+  }
+}

--- a/test/report_bloc_test.dart
+++ b/test/report_bloc_test.dart
@@ -2,6 +2,7 @@ import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pola_flutter/data/api_response.dart';
 import 'package:pola_flutter/data/pola_api_repository.dart';
+import 'package:pola_flutter/models/product_search_response.dart';
 import 'package:pola_flutter/models/search_result.dart';
 import 'package:pola_flutter/pages/report/report_bloc.dart';
 import 'package:pola_flutter/pages/report/report_event.dart';
@@ -143,5 +144,13 @@ class _MockPolaApi extends PolaApi {
     lastDescription = description;
     lastProductId = productId;
     return Future.value(createReportResult);
+  }
+
+  @override
+  Future<ApiResponse<ProductSearchResponse>> searchProducts(
+    String query, {
+    String? pageToken,
+  }) {
+    throw UnimplementedError();
   }
 }

--- a/test/scan_bloc_test.dart
+++ b/test/scan_bloc_test.dart
@@ -3,6 +3,7 @@ import 'package:pola_flutter/analytics/pola_analytics.dart';
 import 'package:pola_flutter/data/api_response.dart';
 import 'package:pola_flutter/data/pola_api_repository.dart';
 import 'package:pola_flutter/models/donate.dart';
+import 'package:pola_flutter/models/product_search_response.dart';
 import 'package:pola_flutter/models/search_result.dart';
 import 'package:pola_flutter/pages/scan/remote_button.dart';
 import 'package:pola_flutter/pages/scan/scan_bloc.dart';
@@ -210,6 +211,14 @@ class _MockPolaApi extends PolaApi {
   @override
   Future<bool> createReport({required String description, int? productId}) =>
       Future.value(true);
+
+  @override
+  Future<ApiResponse<ProductSearchResponse>> searchProducts(
+    String query, {
+    String? pageToken,
+  }) {
+    throw UnimplementedError();
+  }
 }
 
 class _MockScanVibration extends ScanVibration {


### PR DESCRIPTION
## Opis

Closes #170 i #215 

Ten PR zastępuje dotychczasowy webview dla ścieżki `/search` natywnym ekranem wyszukiwania produktów we Flutterze. Implementacja korzysta z endpointu [`GET /a/v4/search`](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/KlubJagiellonski/pola-backend/master/pola/rpc_api/openapi-v1.yaml#/paths/~1a~1v4~1search/get), zachowuje obecny shell aplikacji oraz istniejącą dolną nawigację.

Warstwa UI została przygotowana na podstawie designu z issue, linku do [Figmy](https://www.figma.com/design/BVuJwwHa2uAqAVVtsyCx0H/Pola-REDESIGN?node-id=210-4108&t=9wJOtXvjpROTuUfL-4) i przekazanych screenshotów.

## Zakres zmian

- Dodano obsługę wyszukiwania tekstowego w API:
  - [`lib/data/pola_api_service.dart`](lib/data/pola_api_service.dart)
  - [`lib/data/pola_api_repository.dart`](lib/data/pola_api_repository.dart)
- Dodano modele odpowiedzi `/a/v4/search`:
  - [`lib/models/product_search_response.dart`](lib/models/product_search_response.dart)
- Podmieniono webview `/search` na natywny ekran:
  - [`lib/pages/scan/scan_navigator.dart`](lib/pages/scan/scan_navigator.dart)
  - [`lib/pages/search/search_page.dart`](lib/pages/search/search_page.dart)
- Dodano logikę wyszukiwarki, historii i paginacji:
  - [`lib/pages/search/search_bloc.dart`](lib/pages/search/search_bloc.dart)
  - [`lib/pages/search/search_state.dart`](lib/pages/search/search_state.dart)
  - [`lib/data/product_search_history_service.dart`](lib/data/product_search_history_service.dart)
- Dodano pełny ekran historii wyszukiwania:
  - [`lib/pages/search/search_history_page.dart`](lib/pages/search/search_history_page.dart)
- Wydzielono mniejsze widgety search UI do [`lib/pages/search/widgets`](lib/pages/search/widgets).
- Ujednolicono kafelek produktu i badge punktowy przez współdzielony komponent:
  - [`lib/ui/product_list_item.dart`](lib/ui/product_list_item.dart)
  - [`lib/ui/list_item.dart`](lib/ui/list_item.dart)
- Dodano polskie stringi do [`lib/i18n/en.i18n.json`](lib/i18n/en.i18n.json).

## Decyzje techniczne

- `/search` został zastąpiony natywnym ekranem tylko w aktualnym navigatorze skanera, żeby ograniczyć zakres zmian i nie ruszać pozostałych webview flow.
- Wyszukiwanie jest debouncowane (500ms), żeby nie wykonywać requestu po każdej literze. Dzięki temu UI pozostaje responsywny, a backend nie dostaje nadmiarowych zapytań.
- Minimalna długość query to 2 znaki. Jednoznakowe wyszukiwania zwykle mają słabą wartość użytkową i generują dużo kosztownych wyników.
- Wyniki są cache’owane w ramach życia ekranu. Powrót do tej samej frazy nie wymusza kolejnego requestu.
- Historia zapisuje ostatnio otwarte produkty, nie surowe frazy. To odpowiada rzeczywistemu intentowi użytkownika i pozwala od razu wrócić do produktu.
- `SharedPreferences` wystarcza do historii, bo przechowujemy małą lokalną listę bez relacji i migracji.
- Search response jest traktowany jako lightweight preview. Po tapnięciu produktu nadal pobieramy pełny `SearchResult` przez istniejące `getCompany(code)`, bo ekran szczegółów już opiera się na tym modelu.
- Lista wyników i historia używają `SliverList`, żeby budować wiersze leniwie.
- Kafelki używają `BlocSelector`, żeby podczas otwierania produktu przebudowywał się tylko aktywny wiersz.
- Wspólny `ProductListItem` redukuje duplikację między wynikami skanowania i wynikami wyszukiwania.
- Logowanie `SearchState` zostało uproszczone: transition log pokazuje liczniki i flagi zamiast pełnych list produktów.


wytestowano na QA/Prod/Dev

## Wideo zmian (na Dev)

https://github.com/user-attachments/assets/ae7a356d-85d7-4d00-a594-88ee595edd2a






