### PR TITLE
Fix async ScanBloc event handling

### DIFF
--- a/lib/pages/scan/scan_bloc.dart
+++ b/lib/pages/scan/scan_bloc.dart
@@ -26,10 +26,9 @@ class ScanBloc extends Bloc<ScanEvent, ScanState> {
     this._torchController, {
     ScanState state = const ScanState(),
   }) : super(state) {
-    on<ScanEvent>((event, emit) {
-      event.when(
-        barcodeScanned: (barcode) async =>
-            await _onBarcodeScanned(barcode, emit),
+    on<ScanEvent>((event, emit) async {
+      await event.when<FutureOr<void>>(
+        barcodeScanned: (barcode) => _onBarcodeScanned(barcode, emit),
         alertDialogDismissed: () => _onAlertDialogDismissed(emit),
         torchSwitched: () => _onTorchSwitched(emit),
         closeRemoteButton: () => _onCloseRemoteButton(emit),


### PR DESCRIPTION
Changed ScanBloc event handling to add an await.  
Fixed because of the way sometimes the barcode scan was omitted by the bloc and thus forced the emit call after an event handler completed manually.
<img width="2014" height="1162" alt="image" src="https://github.com/user-attachments/assets/36900228-8b70-49b8-b0f1-fb0c94274015" />
